### PR TITLE
COP-9149: Add Details component

### DIFF
--- a/packages/components/src/Details/Details.jsx
+++ b/packages/components/src/Details/Details.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './Details.scss';
+
+export const DEFAULT_CLASS = 'govuk-details';
+const Details = ({ children, summary, classBlock, classModifiers, className, ...attrs }) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <details {...attrs} className={classes()}>
+    <summary className={classes('summary')}>{summary}</summary>
+    <div className={classes('text')}>
+      {children}
+    </div>
+  </details>;
+};
+
+Details.propTypes = {
+  summary: PropTypes.string.isRequired,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Details.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Details;

--- a/packages/components/src/Details/Details.scss
+++ b/packages/components/src/Details/Details.scss
@@ -1,0 +1,9 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/details/_index";
+
+.govuk-details.no-indent {
+  .govuk-details__text {
+    padding: 0 0 0 0;
+    border-left: none;
+  }
+}

--- a/packages/components/src/Details/Details.stories.mdx
+++ b/packages/components/src/Details/Details.stories.mdx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { Meta, Props, Story, Canvas } from '@storybook/addon-docs';
+import Details from './Details';
+
+<Meta title="Details" id="D-Details" component={ Details } />
+
+# Details
+
+Make a page easier to scan by letting users reveal more detailed information only if they need it.
+
+<Canvas>
+  <Story name="Default">
+    <Details summary="Help with nationality">
+      We need to know your nationality so we can work out which elections you’re entitled to vote in.
+      If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
+    </Details>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ Details } />
+</Details>

--- a/packages/components/src/Details/Details.test.js
+++ b/packages/components/src/Details/Details.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Details, { DEFAULT_CLASS } from './Details';
+
+describe('Details', () => {
+
+  const checkSetup = (container, testId) => {
+    const details = getByTestId(container, testId);
+    expect(details.classList).toContain(DEFAULT_CLASS);
+    const firstChild = details.childNodes[0];
+    expect(firstChild.tagName).toEqual('SUMMARY');
+    expect(firstChild.classList).toContain(`${DEFAULT_CLASS}__summary`);
+    const secondChild = details.childNodes[1];
+    expect(secondChild.tagName).toEqual('DIV');
+    expect(secondChild.classList).toContain(`${DEFAULT_CLASS}__text`);
+    return { details, firstChild, secondChild };
+  };
+
+  it('should display the appropriate summary text in the details', async () => {
+    const DETAILS_ID = 'details';
+    const DETAILS_SUMMARY = 'Hello world!'
+    const DETAILS_TEXT = `Here's some important information for you`;
+    const { container } = render(
+      <Details data-testid={DETAILS_ID} summary={DETAILS_SUMMARY}>{DETAILS_TEXT}</Details>
+    );
+    const { firstChild, secondChild } = checkSetup(container, DETAILS_ID);
+    expect(firstChild.innerHTML).toEqual(DETAILS_SUMMARY);
+    expect(secondChild.innerHTML).toEqual(DETAILS_TEXT);
+  });
+
+  it('should appropriately support classModifiers', async () => {
+    const DETAILS_ID = 'modifiers';
+    const DETAILS_SUMMARY = 'Breaking news';
+    const DETAILS_TEXT = 'Something useful and interesting';
+    const CLASS_MODIFIERS = ['warning', 'test'];
+    const { container } = render(
+      <Details data-testid={DETAILS_ID} summary={DETAILS_SUMMARY} classModifiers={CLASS_MODIFIERS}>{DETAILS_TEXT}</Details>
+    );
+    const { details } = checkSetup(container, DETAILS_ID);
+    CLASS_MODIFIERS.forEach(cm => {
+      expect(details.classList).toContain(`${DEFAULT_CLASS}--${cm}`);
+    });
+  });
+
+});

--- a/packages/components/src/Details/index.js
+++ b/packages/components/src/Details/index.js
@@ -1,0 +1,3 @@
+import Details from './Details';
+
+export default Details;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,7 +1,9 @@
+import Details from './Details';
 import Panel from './Panel';
 import Utils from './utils/Utils';
 
 export {
+  Details,
   Panel,
   Utils
 };


### PR DESCRIPTION
### Description
Added the `Details` component, along with unit tests and a Storybook story.

### Important
This PR depends on the following PR and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`