### PR TITLE
COP-9142: Add Tag component

### DIFF
--- a/packages/components/src/Tag/Tag.jsx
+++ b/packages/components/src/Tag/Tag.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './Tag.scss';
+
+export const DEFAULT_CLASS = 'hods-tag';
+const Tag = ({ children, text, classBlock, classModifiers, className, ...attrs }) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <strong {...attrs} className={classes()}>
+    {text || children}
+  </strong>;
+};
+
+Tag.propTypes = {
+  text: PropTypes.string,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Tag.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Tag;

--- a/packages/components/src/Tag/Tag.scss
+++ b/packages/components/src/Tag/Tag.scss
@@ -1,0 +1,32 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/tag/_index";
+
+@mixin hods-tag-colours($colour) {
+  .hods-tag--#{$colour} {
+    @extend .govuk-tag--#{$colour};
+  }
+}
+
+.hods-tag {
+  @extend .govuk-tag;
+  text-transform: lowercase;
+  &::first-letter {
+    text-transform: uppercase;
+  }
+}
+
+@include hods-tag-colours('inactive'); // Deprecated.
+@include hods-tag-colours('grey');
+@include hods-tag-colours('purple');
+@include hods-tag-colours('turquoise');
+@include hods-tag-colours('blue');
+@include hods-tag-colours('yellow');
+@include hods-tag-colours('orange');
+@include hods-tag-colours('red');
+@include hods-tag-colours('pink');
+@include hods-tag-colours('green');
+
+// This is purely for the Storybook stories.
+.ml10 {
+  margin-left: 10px;
+}

--- a/packages/components/src/Tag/Tag.stories.mdx
+++ b/packages/components/src/Tag/Tag.stories.mdx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import Tag from './Tag';
+import './Tag.stories.scss';
+
+<Meta title="Tag" id="D-Tag" component={ Tag } />
+
+# Tag
+
+A component to display the status of something.
+
+<Canvas>
+  <Story name="Default">
+    <Tag>example tag</Tag>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ Tag } />
+</Details>
+
+### Using colour with tags
+
+You can use colour to help distinguish between different tags – or to help draw the user’s attention to a tag if it’s especially important. For example, it probably makes sense to use `red` for a tag that reads ‘Urgent’.
+
+[Do not use colour alone to convey information] because it’s not accessible. If you use the same tag in more than one place, make sure you keep the colour consistent.
+
+Because tags with solid colours tend to stand out more, it’s usually best to avoid mixing solid colours and tints: use one or the other. This matters less if you’re only using two colours. For example, it’s okay to use the tint `grey` and solid blue tags together if you only need two statuses.
+
+
+#### Additional colours
+
+If you need more tag colours, you can use the following tints.
+
+<Canvas>
+  <Story name="Colours">
+    <table className="govuk-table">
+      <thead className="govuk-table__head">
+        <tr className="govuk-table__row">
+          <th className="govuk-table__header"><code>classModifiers="..."</code></th>
+          <th className="govuk-table__header">Example usage</th>
+        </tr>
+      </thead>
+      <tbody className="govuk-table__body">
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>grey</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="grey">inactive</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>green</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="green">new</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>turquoise</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="turquoise">active</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>blue</code></td><td className="govuk-table__col"><Tag classModifiers="blue">pending</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>purple</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="purple">received</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>pink</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="pink">sent</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>red</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="red">rejected</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>orange</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="orange">declined</Tag></td>
+        </tr>
+        <tr className="govuk-table__row">
+          <td className="govuk-table__col"><code>yellow</code></td>
+          <td className="govuk-table__col"><Tag classModifiers="yellow">delayed</Tag></td>
+        </tr>
+      </tbody>
+    </table>
+  </Story>
+</Canvas>
+
+## Variation from GDS standard
+
+The styling deviates from the GDS one, in which the text within a tag is uppercase. Here,
+the text is in sentence case - i.e., it's all lowercase, apart from the first letter, which is
+capitalised.
+
+In reality, this is *pseudo*-sentence case - it literally transforms everything to lowercase
+and then capitalises the first letter. It will *not* capitalise the first letter of a word
+after a full stop.
+
+To accomplish this, the `classBlock` defaults to `hods-tag`, which extends and overrides
+`govuk-tag`. If you need to display a tag in the GDS format, you can simply set the `classBlock`
+to `govuk-tag`, though this is not advised for Home Office applications.

--- a/packages/components/src/Tag/Tag.stories.scss
+++ b/packages/components/src/Tag/Tag.stories.scss
@@ -1,0 +1,30 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/table/_index";
+
+table {
+  @extend .govuk-table;
+
+  caption {
+    @extend .govuk-table__caption;
+  }
+
+  thead {
+    @extend .govuk-table__head !optional;
+  }
+
+  tbody {
+    @extend .govuk-table__body !optional;
+  }
+
+  tr {
+    @extend .govuk-table__row !optional;
+  }
+
+  th {
+    @extend .govuk-table__header;
+  }
+
+  td {
+    @extend .govuk-table__cell;
+  }
+}

--- a/packages/components/src/Tag/Tag.test.js
+++ b/packages/components/src/Tag/Tag.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Tag, { DEFAULT_CLASS } from './Tag';
+
+describe('Tag', () => {
+
+  const checkSetup = (container, testId) => {
+    const tag = getByTestId(container, testId);
+    expect(tag.classList).toContain(DEFAULT_CLASS);
+    return tag;
+  };
+
+  it('should display the appropriate text as children', async () => {
+    const TAG_ID = 'tag';
+    const TEXT = 'Hello Inset World';
+    const { container } = render(
+      <Tag data-testid={TAG_ID}>{TEXT}</Tag>
+    );
+    const tag = checkSetup(container, TAG_ID);
+    expect(tag.innerHTML).toEqual(TEXT);
+  });
+
+  it('should override any children with the text attribute', async () => {
+    const TAG_ID = 'text';
+    const CHILDREN = 'Hello Tag World';
+    const TEXT = 'This should show instead';
+    const { container } = render(
+      <Tag data-testid={TAG_ID} text={TEXT}>{CHILDREN}</Tag>
+    );
+    const tag = checkSetup(container, TAG_ID);
+    expect(tag.innerHTML).toEqual(TEXT);
+  });
+
+  it('should display the appropriate markup', async () => {
+    const TAG_ID = 'markup';
+    const INNER_DIV_ID = 'inner-div';
+    const INNER_DIV_TEXT = 'Inner div text';
+    const INNER_MARKUP = <div data-testid={INNER_DIV_ID}>
+      {INNER_DIV_TEXT}
+    </div>;
+    const { container } = render(
+      <Tag data-testid={TAG_ID}>{INNER_MARKUP}</Tag>
+    );
+    const tag = checkSetup(container, TAG_ID);
+    const innerDiv = getByTestId(tag, INNER_DIV_ID);
+    expect(innerDiv.innerHTML).toEqual(INNER_DIV_TEXT);
+  });
+
+  it('should correctly pick up the classModifiers', async () => {
+    const TAG_ID = 'modifiers';
+    const CHILDREN = 'Modifiers';
+    const CLASS_MODIFIERS = 'red';
+    const { container } = render(
+      <Tag data-testid={TAG_ID} classModifiers={CLASS_MODIFIERS}>{CHILDREN}</Tag>
+    );
+    const tag = checkSetup(container, TAG_ID);
+    expect(tag.innerHTML).toEqual(CHILDREN);
+    expect(tag.classList).toContain(`${DEFAULT_CLASS}--${CLASS_MODIFIERS}`);
+  });
+
+});

--- a/packages/components/src/Tag/index.js
+++ b/packages/components/src/Tag/index.js
@@ -1,0 +1,3 @@
+import Tag from './Tag';
+
+export default Tag;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,9 +1,11 @@
 import Details from './Details';
 import Panel from './Panel';
+import Tag from './Tag';
 import Utils from './utils/Utils';
 
 export {
   Details,
   Panel,
+  Tag,
   Utils
 };


### PR DESCRIPTION
### Description
Added the `Tag` component, along with unit tests and a Storybook story.

The styling has also been overridden from the GDS standard so that the text displays in sentence case, rather than capitalised.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`