### PR TITLE
COP-9037: Add InsetText component

### DIFF
--- a/packages/components/src/InsetText/InsetText.jsx
+++ b/packages/components/src/InsetText/InsetText.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './InsetText.scss';
+
+export const DEFAULT_CLASS = 'govuk-inset-text';
+const InsetText = ({ children, classBlock, classModifiers, className, ...attrs }) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <div {...attrs} className={classes()}>
+    {children}
+  </div>;
+};
+
+InsetText.propTypes = {
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+InsetText.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default InsetText;

--- a/packages/components/src/InsetText/InsetText.scss
+++ b/packages/components/src/InsetText/InsetText.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/inset-text/_index";

--- a/packages/components/src/InsetText/InsetText.stories.mdx
+++ b/packages/components/src/InsetText/InsetText.stories.mdx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import InsetText from './InsetText';
+
+<Meta title="InsetText" id="D-InsetText" component={ InsetText } />
+
+# Inset text
+
+A block of text that is inset.
+
+<Canvas>
+  <Story name="Default">
+    <InsetText>
+      The changes will show in your profile when they accept your request.
+    </InsetText>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ InsetText } />
+</Details>
+
+# Variants
+## With markup
+
+A block of markup that is inset, showing it supports something other than plain text.
+
+<Canvas>
+  <Story name="Markup">
+    <InsetText>
+      <ol>
+        <li>Check your answers carefully</li>
+        <li>Don't make a mistake</li>
+      </ol>
+    </InsetText>
+  </Story>
+</Canvas>

--- a/packages/components/src/InsetText/InsetText.test.js
+++ b/packages/components/src/InsetText/InsetText.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import InsetText from './InsetText';
+
+describe('InsetText', () => {
+
+  const checkSetup = (container, testId) => {
+    const insetText = getByTestId(container, testId);
+    expect(insetText.classList).toContain('govuk-inset-text');
+    return insetText;
+  };
+
+  it('should display the appropriate text', async () => {
+    const TEXT_ID = 'indent';
+    const TEXT = 'Hello Inset World';
+    const { container } = render(
+      <InsetText data-testid={TEXT_ID}>{TEXT}</InsetText>
+    );
+    const insetText = checkSetup(container, TEXT_ID);
+    expect(insetText.innerHTML).toEqual(TEXT);
+  });
+
+  it('should display the appropriate markup', async () => {
+    const TEXT_ID = 'markup';
+    const INNER_DIV_ID = 'inner-div';
+    const INNER_DIV_TEXT = 'Inner div text';
+    const INNER_MARKUP = <div data-testid={INNER_DIV_ID}>
+      {INNER_DIV_TEXT}
+    </div>;
+    const { container } = render(
+      <InsetText data-testid={TEXT_ID}>{INNER_MARKUP}</InsetText>
+    );
+    const insetText = checkSetup(container, TEXT_ID);
+    const innerDiv = getByTestId(insetText, INNER_DIV_ID);
+    expect(innerDiv.innerHTML).toEqual(INNER_DIV_TEXT);
+  });
+
+});

--- a/packages/components/src/InsetText/index.js
+++ b/packages/components/src/InsetText/index.js
@@ -1,0 +1,3 @@
+import InsetText from './InsetText';
+
+export default InsetText;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,10 +1,12 @@
 import Details from './Details';
+import InsetText from './InsetText';
 import Panel from './Panel';
 import Tag from './Tag';
 import Utils from './utils/Utils';
 
 export {
   Details,
+  InsetText,
   Panel,
   Tag,
   Utils


### PR DESCRIPTION
### Description
Added the `InsetText` component, along with unit tests and Storybook stories.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`