### PR TITLE
COP-9039: Add Alert component

### DIFF
--- a/packages/components/src/Alert/Alert.jsx
+++ b/packages/components/src/Alert/Alert.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InsetText from '../InsetText';
+import { classBuilder } from '../utils/Utils';
+import './Alert.scss';
+
+export const DEFAULT_CLASS = 'hods-alert';
+const Alert = ({
+  children,
+  heading,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return (
+    <InsetText {...attrs} classBlock={classBlock} classModifiers={classModifiers} className={className}>
+      <h2 className={classes('heading')}>{heading}</h2>
+      <p>{children}</p>
+    </InsetText>
+  );
+};
+
+Alert.propTypes = {
+  heading: PropTypes.string.isRequired,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Alert.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Alert;

--- a/packages/components/src/Alert/Alert.scss
+++ b/packages/components/src/Alert/Alert.scss
@@ -1,0 +1,32 @@
+
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/inset-text/_index";
+
+.hods-alert {
+  @extend .govuk-inset-text;
+  border-color: #2b8cc4;
+  background-color: #dbeff9;
+
+  &--success {
+    border-color: #28a197;
+    background-color: #c6ece9;
+  }
+
+  &--error {
+    border-color: #c42b2b;
+    background-color: #f3dede;
+  }
+
+  &:first-child {
+    @include govuk-responsive-margin(0, "top");
+  }
+
+  &:last-child {
+    @include govuk-responsive-margin(0, "bottom");
+  }
+
+  &__heading {
+    @include govuk-font(24, 'bold');
+    @include govuk-responsive-margin(3, "bottom");
+  }
+}

--- a/packages/components/src/Alert/Alert.stories.mdx
+++ b/packages/components/src/Alert/Alert.stories.mdx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import Alert from './Alert';
+
+<Meta title="Alert" id="D-Alert" component={ Alert } />
+
+# Alert
+
+A block of text that is inset.
+
+<Canvas>
+  <Story name="Default">
+    <Alert heading="New passport">
+      We'll send your new passport by secure delivery. The cost is included in the passport fee.
+    </Alert>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ Alert } />
+</Details>
+
+# Variants
+## Success
+
+Use the green version of the alert to confirm that something they’re expecting to happen has happened.
+
+<Canvas>
+  <Story name="Success">
+    <Alert heading="Payment successful" classModifiers="success">
+      We've sent details to test-email@test-corp.co.uk<br /><a href="#">Download confirmation</a>
+    </Alert>
+  </Story>
+</Canvas>
+
+## Error
+
+Use the red version of the alert to confirm that something has gone wrong.
+
+<Canvas>
+  <Story name="Error">
+    <Alert heading="Payment unsuccessful" classModifiers="error">
+      Please try again or contact our <a href="#">support team</a> for assistance.
+    </Alert>
+  </Story>
+</Canvas>

--- a/packages/components/src/Alert/Alert.test.js
+++ b/packages/components/src/Alert/Alert.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Alert, { DEFAULT_CLASS } from './Alert';
+
+describe('Alert', () => {
+
+  const checkSetup = (container, testId) => {
+    const alert = getByTestId(container, testId);
+    expect(alert.classList).toContain(DEFAULT_CLASS);
+    const firstChild = alert.childNodes[0];
+    expect(firstChild.tagName).toEqual('H2');
+    expect(firstChild.classList).toContain(`${DEFAULT_CLASS}__heading`);
+    const secondChild = alert.childNodes[1];
+    expect(secondChild.tagName).toEqual('P');
+    return { alert, firstChild, secondChild };
+  };
+
+  it('should display the appropriate text in the alert', async () => {
+    const ALERT_ID = 'alert';
+    const ALERT_HEADING = 'Hello world!'
+    const ALERT_TEXT = `Don't panic!`;
+    const { container } = render(
+      <Alert data-testid={ALERT_ID} heading={ALERT_HEADING}>{ALERT_TEXT}</Alert>
+    );
+    const { firstChild, secondChild } = checkSetup(container, ALERT_ID);
+    expect(firstChild.innerHTML).toEqual(ALERT_HEADING);
+    expect(secondChild.innerHTML).toEqual(ALERT_TEXT);
+  });
+
+  it('should appropriately support classModifiers', async () => {
+    const ALERT_ID = 'modifiers';
+    const ALERT_HEADING = 'It worked!'
+    const ALERT_TEXT = 'Great news, everyone.';
+    const CLASS_MODIFIERS = ['success', 'test'];
+    const { container } = render(
+      <Alert data-testid={ALERT_ID} heading={ALERT_HEADING} classModifiers={CLASS_MODIFIERS}>{ALERT_TEXT}</Alert>
+    );
+    const { alert } = checkSetup(container, ALERT_ID);
+    CLASS_MODIFIERS.forEach(cm => {
+      expect(alert.classList).toContain(`${DEFAULT_CLASS}--${cm}`);
+    });
+  });
+
+});

--- a/packages/components/src/Alert/index.js
+++ b/packages/components/src/Alert/index.js
@@ -1,0 +1,3 @@
+import Alert from './Alert';
+
+export default Alert;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,3 +1,4 @@
+import Alert from './Alert';
 import Details from './Details';
 import InsetText from './InsetText';
 import Panel from './Panel';
@@ -6,6 +7,7 @@ import TextInput from './TextInput';
 import Utils from './utils/Utils';
 
 export {
+  Alert,
   Details,
   InsetText,
   Panel,


### PR DESCRIPTION
### Description
Added the `Alert` component, along with unit tests and Storybook stories.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4
    * https://github.com/UKHomeOffice/cop-react-design-system/pull/7

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`