### PR TITLE
COP-8969: Add TextInput component

### DIFF
--- a/packages/components/src/TextInput/TextInput.jsx
+++ b/packages/components/src/TextInput/TextInput.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder, toArray } from '../utils/Utils';
+import './TextInput.scss';
+
+export const DEFAULT_CLASS = 'govuk-input';
+const TextInput = ({
+  id,
+  fieldId,
+  disabled,
+  error,
+  classBlock,
+  classModifiers: _classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classModifiers = [...toArray(_classModifiers), error ? 'error' : undefined ];
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return (
+    <input
+      {...attrs}
+      disabled={disabled}
+      id={id}
+      name={fieldId}
+      type="text"
+      className={classes()}
+    />
+  );
+};
+
+TextInput.propTypes = {
+  id: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+TextInput.defaultProps = {
+  classBlock: DEFAULT_CLASS,
+  classModifiers: []
+};
+
+TextInput.displayName = 'TextInput';
+
+export default TextInput;

--- a/packages/components/src/TextInput/TextInput.scss
+++ b/packages/components/src/TextInput/TextInput.scss
@@ -1,0 +1,1 @@
+@import "node_modules/govuk-frontend/govuk/components/input/input";

--- a/packages/components/src/TextInput/TextInput.stories.mdx
+++ b/packages/components/src/TextInput/TextInput.stories.mdx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import TextInput from './TextInput';
+
+<Meta title="Text input" id="D-TextInput" component={ TextInput } />
+
+# Text input
+
+<Canvas>
+  <Story name="Default">
+    <TextInput id="input" fieldId="input" />
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ TextInput } />
+</Details>
+
+# Variants
+## Disabled
+
+A disabled text input.
+
+<Canvas>
+  <Story name="Disabled">
+    <TextInput id="disabledInput" fieldId="disabledInput" disabled={true} />
+  </Story>
+</Canvas>
+
+## Error
+
+A text input in an error state.
+
+<Canvas>
+  <Story name="Error">
+    <TextInput id="errorInput" fieldId="errorInput" error="This is an error" />
+  </Story>
+</Canvas>
+
+## Track changes
+
+A text input with an `onChange` handler that tracks changes as you type.
+
+<Canvas>
+  <Story name="Track changes">
+    {() => {
+      const [value, setValue] = useState({});
+      const [changes, setChanges] = useState([]);
+      const onChange = ({ target }) => {
+        setValue(prev => {
+          const next = { ...prev, [target.name]: target.value };
+          setChanges(prevChanges => {
+            return [...prevChanges, { ts: Date.now(), value: next }];
+          });
+          return next;
+        });
+      };
+      const fieldId = 'textInput';
+      const options = {
+        id: 'textInput',
+        fieldId,
+        value: value[fieldId] || '',
+        onChange
+      };
+      return (
+        <>
+          <TextInput {...options} />
+          {changes && 
+            <>
+              <br /><br />
+              <Details summary="Change series" className="no-indent">
+                <ol>
+                  {changes && changes.map(change => (
+                    <li key={change.ts}>{JSON.stringify(change.value)}</li>
+                  ))}
+                </ol>
+              </Details>
+            </>
+          }
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/components/src/TextInput/TextInput.test.js
+++ b/packages/components/src/TextInput/TextInput.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { fireEvent, getByTestId, render } from '@testing-library/react';
+import TextInput, { DEFAULT_CLASS } from './TextInput';
+
+describe('TextInput', () => {
+
+  const checkSetup = (container, testId) => {
+    const input = getByTestId(container, testId);
+    expect(input.classList).toContain(DEFAULT_CLASS);
+    return input;
+  };
+
+  it('should be appropriately set up with id and name', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const { container } = render(
+      <TextInput data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} />
+    );
+    const input = checkSetup(container, INPUT_ID);
+    expect(input.name).toEqual(INPUT_FIELD_ID);
+    expect(input.type).toEqual('text');
+    expect(input.value).toEqual('');
+    expect(input.getAttribute('disabled')).toBeNull();
+  });
+
+  it('should be accept the disabled flag', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const { container } = render(
+      <TextInput data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} disabled={true} />
+    );
+    const input = checkSetup(container, INPUT_ID);
+    expect(input.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('should be in an error state when the error is set', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const ERROR = 'This is in error';
+    const { container } = render(
+      <TextInput data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} error={ERROR} />
+    );
+    const input = checkSetup(container, INPUT_ID);
+    expect(input.classList).toContain(`${DEFAULT_CLASS}--error`);
+    expect(input.value).toEqual('');
+  });
+
+  it('should not be in an error state when the error is an empty string', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const ERROR = '';
+    const { container } = render(
+      <TextInput data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID} error={ERROR} />
+    );
+    const input = checkSetup(container, INPUT_ID);
+    expect(input.classList).not.toContain(`${DEFAULT_CLASS}--error`);
+    expect(input.value).toEqual('');
+  });
+
+  it('should set the value and onChange on the underlying input appropriately', async () => {
+    const INPUT_ID = 'input';
+    const INPUT_FIELD_ID = 'inputFieldId';
+    const VALUE = 'This is the value';
+    let onChangeCalls = 0;
+    const ON_CHANGE = () => {
+      onChangeCalls++;
+    };
+    const { container } = render(
+      <TextInput
+        data-testid={INPUT_ID} id={INPUT_ID} fieldId={INPUT_FIELD_ID}
+        value={VALUE} onChange={ON_CHANGE} />
+    );
+    const input = checkSetup(container, INPUT_ID);
+    expect(input.value).toEqual(VALUE);
+    expect(onChangeCalls).toEqual(0);
+    const EVENT = { target: { name: INPUT_FIELD_ID, value: `${VALUE}.` } };
+    fireEvent.change(input, EVENT);
+    expect(onChangeCalls).toEqual(1);
+  });
+
+});

--- a/packages/components/src/TextInput/index.js
+++ b/packages/components/src/TextInput/index.js
@@ -1,0 +1,3 @@
+import TextInput from './TextInput';
+
+export default TextInput;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -2,6 +2,7 @@ import Details from './Details';
 import InsetText from './InsetText';
 import Panel from './Panel';
 import Tag from './Tag';
+import TextInput from './TextInput';
 import Utils from './utils/Utils';
 
 export {
@@ -9,5 +10,6 @@ export {
   InsetText,
   Panel,
   Tag,
+  TextInput,
   Utils
 };


### PR DESCRIPTION
### Description
Added the `TextInput` component, along with unit tests and Storybook stories.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`