### PR TITLE
COP-9138: Add Label component

### DIFF
--- a/packages/components/src/Label/Label.jsx
+++ b/packages/components/src/Label/Label.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './Label.scss';
+
+export const OPTIONAL_SUFFIX = ' (optional)';
+export const DEFAULT_CLASS = 'govuk-label';
+const Label = ({
+  children,
+  id,
+  required,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <label {...attrs} htmlFor={id} className={classes()}>
+    {children}
+    {!required && typeof(children) === 'string' && OPTIONAL_SUFFIX}
+  </label>;
+};
+
+Label.propTypes = {
+  id: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Label.defaultProps = {
+  required: false,
+  classBlock: DEFAULT_CLASS
+};
+
+export default Label;

--- a/packages/components/src/Label/Label.scss
+++ b/packages/components/src/Label/Label.scss
@@ -1,0 +1,1 @@
+@import "node_modules/govuk-frontend/govuk/components/label/label";

--- a/packages/components/src/Label/Label.stories.mdx
+++ b/packages/components/src/Label/Label.stories.mdx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import Label from './Label';
+import Tag from '../Tag';
+
+<Meta
+  id="D-Label"
+  title="Internal/Label"
+  component={ Label }
+/>
+
+# Label
+
+<p><Tag text="Internal" /></p>
+
+A label for a form field.
+
+<Canvas>
+  <Story name="Default">
+    <form action="#" method="get">
+      <Label id="form-field">Form field</Label>
+      <input className="govuk-input" id="form-field" />
+    </form>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ Label } />
+</Details>
+
+# Variants
+## Optional
+An optional field has an `(optional)` suffix.
+
+<Canvas>
+  <Story name="Optional">
+    <form action="#" method="get">
+      <Label id="optional-field">Optional field</Label>
+      <input className="govuk-input" id="optional-field" />
+    </form>
+  </Story>
+</Canvas>
+
+## Required
+A required field displays without the `(optional)` suffix.
+
+<Canvas>
+  <Story name="Required">
+    <form action="#" method="get">
+      <Label id="required-field" required={true}>Required field</Label>
+      <input className="govuk-input" id="required-field" />
+    </form>
+  </Story>
+</Canvas>
+
+## With markup
+A label that contains markup.
+
+**Note:** this will <em>not</em> display the `(optional)` suffix as it contains markup.
+
+<Canvas>
+  <Story name="Markup">
+    <form action="#" method="get">
+      <Label id="markup-field">
+        This is normal apart from the <strong>bold</strong> bit
+        and the <em>italic</em> bit (and the <a href="#">link</a>)
+      </Label>
+      <input className="govuk-input" id="markup-field" />
+    </form>
+  </Story>
+</Canvas>
+
+## Inline
+A label that contains the field to which it refers.
+
+**Note:** this will <em>not</em> display the `(optional)` suffix as it contains markup.
+
+<Canvas>
+  <Story name="Inline">
+    <form action="#" method="get">
+      <Label id="inline-field">
+        Inline label
+        <input className="govuk-input" id="inline-field" />
+      </Label>
+    </form>
+  </Story>
+</Canvas>

--- a/packages/components/src/Label/Label.test.js
+++ b/packages/components/src/Label/Label.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Label, { OPTIONAL_SUFFIX } from './Label';
+
+describe('Label', () => {
+
+  const checkSetup = (container, testId) => {
+    const label = getByTestId(container, testId);
+    expect(label.getAttribute('for')).toEqual(testId);
+    expect(label.classList).toContain('govuk-label');
+    return label;
+  };
+
+  it('should include the suffix in an optional label', async () => {
+    const LABEL_ID = 'opt';
+    const LABEL_TEXT = 'Optional label';
+    const { container } = render(
+      <Label data-testid={LABEL_ID} id={LABEL_ID}>{LABEL_TEXT}</Label>
+    );
+    const label = checkSetup(container, LABEL_ID);
+    expect(label.innerHTML).toEqual(`${LABEL_TEXT}${OPTIONAL_SUFFIX}`);
+  });
+
+  it('should not include the suffix in a required label', async () => {
+    const LABEL_ID = 'req';
+    const LABEL_TEXT = 'Required label';
+    const { container } = render(
+      <Label data-testid={LABEL_ID} id={LABEL_ID} required={true}>{LABEL_TEXT}</Label>
+    );
+    const label = checkSetup(container, LABEL_ID);
+    expect(label.innerHTML).toEqual(LABEL_TEXT);
+  });
+
+  it('should appropriately embed HTML as a child in an optional label not include the suffix', async () => {
+    const LABEL_ID = 'embed';
+    const INNER_DIV_ID = 'inner-div';
+    const INNER_DIV_TEXT = 'Inner div text';
+    const LABEL_MARKUP = <div data-testid={INNER_DIV_ID}>
+      {INNER_DIV_TEXT}
+    </div>;
+    const { container } = render(
+      <Label data-testid={LABEL_ID} id={LABEL_ID}>{LABEL_MARKUP}</Label>
+    );
+    const label = checkSetup(container, LABEL_ID);
+    const innerDiv = getByTestId(label, INNER_DIV_ID);
+    expect(innerDiv.innerHTML).toEqual(INNER_DIV_TEXT); // No suffix included.
+  });
+
+});

--- a/packages/components/src/Label/index.js
+++ b/packages/components/src/Label/index.js
@@ -1,0 +1,3 @@
+import Label from './Label';
+
+export default Label;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,6 +1,7 @@
 import Alert from './Alert';
 import Details from './Details';
 import InsetText from './InsetText';
+import Label from './Label';
 import Panel from './Panel';
 import Tag from './Tag';
 import TextInput from './TextInput';
@@ -10,6 +11,7 @@ export {
   Alert,
   Details,
   InsetText,
+  Label,
   Panel,
   Tag,
   TextInput,


### PR DESCRIPTION
### Description
Added the `Label` component, along with unit tests and Storybook stories.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4
    * https://github.com/UKHomeOffice/cop-react-design-system/pull/5

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`