### PR TITLE
COP-9134: Add Hint component

### DIFF
--- a/packages/components/src/Hint/Hint.jsx
+++ b/packages/components/src/Hint/Hint.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './Hint.scss';
+
+export const DEFAULT_CLASS = 'govuk-hint';
+const Hint = ({ children, classBlock, classModifiers, className, ...attrs }) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <span {...attrs} className={classes()}>
+    {children}
+  </span>;
+};
+
+Hint.propTypes = {
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Hint.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Hint;

--- a/packages/components/src/Hint/Hint.scss
+++ b/packages/components/src/Hint/Hint.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/hint";

--- a/packages/components/src/Hint/Hint.stories.mdx
+++ b/packages/components/src/Hint/Hint.stories.mdx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import Hint from './Hint';
+import Tag from '../Tag';
+
+<Meta title="Internal/Hint" id="D-Hint" component={ Hint } />
+
+# Hint
+
+<p><Tag text="Internal" /></p>
+
+A hint for a form field.
+
+<Canvas>
+  <Story name="Default">
+    <Hint>This is a hint</Hint>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ Hint } />
+</Details>
+
+# Variants
+## With markup
+
+A hint that contains markup, showing it supports something other than plain text.
+
+<Canvas>
+  <Story name="Markup">
+    <Hint>
+      <ol>
+        <li>Check your answers carefully</li>
+        <li>Don't make a mistake</li>
+      </ol>
+    </Hint>
+  </Story>
+</Canvas>

--- a/packages/components/src/Hint/Hint.test.js
+++ b/packages/components/src/Hint/Hint.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Hint from './Hint';
+
+describe('Hint', () => {
+
+  const checkSetup = (container, testId) => {
+    const hint = getByTestId(container, testId);
+    expect(hint.classList).toContain('govuk-hint');
+    return hint;
+  };
+
+  it('should display the appropriate text in the hint', async () => {
+    const HINT_ID = 'embedded';
+    const HINT_TEXT = 'Hello Hint World';
+    const { container } = render(
+      <Hint data-testid={HINT_ID}>{HINT_TEXT}</Hint>
+    );
+    const hint = checkSetup(container, HINT_ID);
+    expect(hint.innerHTML).toEqual(HINT_TEXT);
+  });
+
+  it('should display the appropriate markup in the hint', async () => {
+    const HINT_ID = 'markup';
+    const INNER_DIV_ID = 'inner-div';
+    const INNER_DIV_TEXT = 'Inner div text';
+    const HINT_MARKUP = <div data-testid={INNER_DIV_ID}>
+      {INNER_DIV_TEXT}
+    </div>;
+    const { container } = render(
+      <Hint data-testid={HINT_ID}>{HINT_MARKUP}</Hint>
+    );
+    const hint = checkSetup(container, HINT_ID);
+    const innerDiv = getByTestId(hint, INNER_DIV_ID);
+    expect(innerDiv.innerHTML).toEqual(INNER_DIV_TEXT);
+  });
+
+});

--- a/packages/components/src/Hint/index.js
+++ b/packages/components/src/Hint/index.js
@@ -1,0 +1,3 @@
+import Hint from './Hint';
+
+export default Hint;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,5 +1,6 @@
 import Alert from './Alert';
 import Details from './Details';
+import Hint from './Hint';
 import InsetText from './InsetText';
 import Label from './Label';
 import Panel from './Panel';
@@ -10,6 +11,7 @@ import Utils from './utils/Utils';
 export {
   Alert,
   Details,
+  Hint,
   InsetText,
   Label,
   Panel,


### PR DESCRIPTION
### Description
Added the `Hint` component, along with unit tests and Storybook stories.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4
    * https://github.com/UKHomeOffice/cop-react-design-system/pull/5

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`