### PR TITLE
COP-9141: Add VisuallyHidden component

### DIFF
--- a/packages/components/src/VisuallyHidden/VisuallyHidden.jsx
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './VisuallyHidden.scss';
+
+const VisuallyHidden = ({ children, classBlock, classModifiers, className, ...attrs }) => {
+  const classes = classBuilder('govuk-visually-hidden', classBlock, classModifiers, className);
+  return <span {...attrs} className={classes()}>
+    {children}
+  </span>;
+};
+
+VisuallyHidden.propTypes = {
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+export default VisuallyHidden;

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.scss
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/utilities/_visually-hidden";

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.stories.mdx
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.stories.mdx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import VisuallyHidden from './VisuallyHidden';
+import Tag from '../Tag';
+import './VisuallyHidden.stories.scss';
+
+<Meta title="Internal/VisuallyHidden" id="D-VisuallyHidden" component={ VisuallyHidden } />
+
+# Visually hidden
+
+<p><Tag text="Internal" /></p>
+
+Invisible text that can be read by software such as screen-readers.
+
+In the example below, note that there is a visually-hidden prefix of "Error:",
+which will be picked up by screen-readers.
+
+<Canvas>
+  <Story name="Default">
+    <div className="govuk-error-message">
+      <VisuallyHidden>Error:</VisuallyHidden> Something went wrong
+    </div>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ VisuallyHidden } />
+</Details>

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.stories.scss
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.stories.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/error-message";

--- a/packages/components/src/VisuallyHidden/VisuallyHidden.test.js
+++ b/packages/components/src/VisuallyHidden/VisuallyHidden.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import VisuallyHidden from './VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+
+  const checkSetup = (container, testId) => {
+    const visuallyHidden = getByTestId(container, testId);
+    expect(visuallyHidden.classList).toContain('govuk-visually-hidden');
+    return visuallyHidden;
+  };
+
+  it('should include the appropriate text', async () => {
+    const VISUALLY_HIDDEN_ID = 'text';
+    const VISUALLY_HIDDEN_TEXT = 'Invisible Hello World';
+    const { container } = render(
+      <VisuallyHidden data-testid={VISUALLY_HIDDEN_ID}>{VISUALLY_HIDDEN_TEXT}</VisuallyHidden>
+    );
+    const visuallyHidden = checkSetup(container, VISUALLY_HIDDEN_ID);
+    expect(visuallyHidden.innerHTML).toEqual(VISUALLY_HIDDEN_TEXT);
+  });
+
+  it('should include the appropriate markup', async () => {
+    const VISUALLY_HIDDEN_ID = 'markup';
+    const INNER_DIV_ID = 'inner-div';
+    const INNER_DIV_TEXT = 'Inner div text';
+    const VISUALLY_HIDDEN_MARKUP = <div data-testid={INNER_DIV_ID}>
+      {INNER_DIV_TEXT}
+    </div>;
+    const { container } = render(
+      <VisuallyHidden data-testid={VISUALLY_HIDDEN_ID}>{VISUALLY_HIDDEN_MARKUP}</VisuallyHidden>
+    );
+    const visuallyHidden = checkSetup(container, VISUALLY_HIDDEN_ID);
+    const innerDiv = getByTestId(visuallyHidden, INNER_DIV_ID);
+    expect(innerDiv.innerHTML).toEqual(INNER_DIV_TEXT);
+  });
+
+});

--- a/packages/components/src/VisuallyHidden/index.js
+++ b/packages/components/src/VisuallyHidden/index.js
@@ -1,0 +1,3 @@
+import VisuallyHidden from './VisuallyHidden';
+
+export default VisuallyHidden;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -7,6 +7,7 @@ import Panel from './Panel';
 import Tag from './Tag';
 import TextInput from './TextInput';
 import Utils from './utils/Utils';
+import VisuallyHidden from './VisuallyHidden';
 
 export {
   Alert,
@@ -17,5 +18,6 @@ export {
   Panel,
   Tag,
   TextInput,
-  Utils
+  Utils,
+  VisuallyHidden
 };


### PR DESCRIPTION
### Description
Added the `VisuallyHidden` component, along with unit tests and a Storybook story.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4
    * https://github.com/UKHomeOffice/cop-react-design-system/pull/5

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`