### PR TITLE
COP-9040: Add ErrorMessage component

### DIFF
--- a/packages/components/src/ErrorMessage/ErrorMessage.jsx
+++ b/packages/components/src/ErrorMessage/ErrorMessage.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import VisuallyHidden from '../VisuallyHidden';
+import './ErrorMessage.scss';
+
+export const DEFAULT_CLASS = 'govuk-error-message';
+const ErrorMessage = ({ children, classBlock, classModifiers, className, ...attrs }) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <span {...attrs} className={classes()}>
+    <VisuallyHidden>Error:</VisuallyHidden>
+    {children}
+  </span>;
+};
+
+ErrorMessage.propTypes = {
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+ErrorMessage.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default ErrorMessage;

--- a/packages/components/src/ErrorMessage/ErrorMessage.scss
+++ b/packages/components/src/ErrorMessage/ErrorMessage.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/error-message";

--- a/packages/components/src/ErrorMessage/ErrorMessage.stories.mdx
+++ b/packages/components/src/ErrorMessage/ErrorMessage.stories.mdx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import ErrorMessage from './ErrorMessage';
+
+<Meta title="ErrorMessage" id="D-ErrorMessage" component={ ErrorMessage } />
+
+# Error message
+
+Follow the validation pattern and show an error message when there is a
+validation error. In the error message explain what went wrong and how to fix
+it.
+
+<Canvas>
+  <Story name="Default">
+    <ErrorMessage>Your date of birth must be in the past</ErrorMessage>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ ErrorMessage } />
+</Details>

--- a/packages/components/src/ErrorMessage/ErrorMessage.test.js
+++ b/packages/components/src/ErrorMessage/ErrorMessage.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import ErrorMessage from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+
+  const checkSetup = (container, testId) => {
+    const errorMessage = getByTestId(container, testId);
+    expect(errorMessage.classList).toContain('govuk-error-message');
+    const firstChild = errorMessage.childNodes[0];
+    expect(firstChild.classList).toContain('govuk-visually-hidden');
+    expect(firstChild.innerHTML).toEqual('Error:');
+    return errorMessage;
+  };
+
+  it('should display the appropriate text in the error message', async () => {
+    const ERROR_MESSAGE_ID = 'error';
+    const ERROR_MESSAGE_TEXT = 'Hello Broken World';
+    const { container } = render(
+      <ErrorMessage data-testid={ERROR_MESSAGE_ID}>{ERROR_MESSAGE_TEXT}</ErrorMessage>
+    );
+    const errorMessage = checkSetup(container, ERROR_MESSAGE_ID);
+    const secondChild = errorMessage.childNodes[1];
+    expect(secondChild.nodeValue).toEqual(ERROR_MESSAGE_TEXT);
+  });
+
+  it('should display the appropriate markup in the error message', async () => {
+    const ERROR_MESSAGE_ID = 'markup';
+    const INNER_DIV_ID = 'inner-div';
+    const INNER_DIV_TEXT = 'Inner div text';
+    const ERROR_MESSAGE_MARKUP = <div data-testid={INNER_DIV_ID}>
+      {INNER_DIV_TEXT}
+    </div>;
+    const { container } = render(
+      <ErrorMessage data-testid={ERROR_MESSAGE_ID}>{ERROR_MESSAGE_MARKUP}</ErrorMessage>
+    );
+    const errorMessage = checkSetup(container, ERROR_MESSAGE_ID);
+    const innerDiv = getByTestId(errorMessage, INNER_DIV_ID);
+    expect(innerDiv.innerHTML).toEqual(INNER_DIV_TEXT);
+  });
+
+});

--- a/packages/components/src/ErrorMessage/index.js
+++ b/packages/components/src/ErrorMessage/index.js
@@ -1,0 +1,3 @@
+import ErrorMessage from './ErrorMessage';
+
+export default ErrorMessage;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,5 +1,6 @@
 import Alert from './Alert';
 import Details from './Details';
+import ErrorMessage from './ErrorMessage';
 import Hint from './Hint';
 import InsetText from './InsetText';
 import Label from './Label';
@@ -12,6 +13,7 @@ import VisuallyHidden from './VisuallyHidden';
 export {
   Alert,
   Details,
+  ErrorMessage,
   Hint,
   InsetText,
   Label,


### PR DESCRIPTION
### Description
Added the `ErrorMessage` component, along with unit tests and a Storybook story.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4
    * https://github.com/UKHomeOffice/cop-react-design-system/pull/5
      * https://github.com/UKHomeOffice/cop-react-design-system/pull/12

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`