### PR TITLE
COP-9036: Add Button, ButtonGroup, and Link components

### DIFF
--- a/packages/components/src/Button/Button.jsx
+++ b/packages/components/src/Button/Button.jsx
@@ -1,0 +1,100 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import Link from '../Link';
+import { classBuilder, toArray } from '../utils/Utils';
+import './Button.scss';
+
+export const DEFAULT_CLASS = 'govuk-button';
+export const START_BUTTON_LABEL = 'Start now';
+
+const isAnchor = (href) => {
+  return !!href;
+};
+const getStartIcon = (classes) => (
+  <svg
+    className={classes('start-icon')}
+    xmlns="http://www.w3.org/2000/svg"
+    width="17.5"
+    height="19"
+    viewBox="0 0 33 40"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+  </svg>
+);
+
+const getLinkButton = ({ children, ...attrs }) => (
+  <Link {...attrs} role="button">{children}</Link>
+);
+
+const getButton = ({ children, disabled, className, ...attrs }) => (
+  <button
+    data-module={DEFAULT_CLASS}
+    aria-disabled={disabled}
+    disabled={disabled}
+    {...attrs}
+    className={className}
+  >
+    {children}
+  </button>
+);
+
+export const Button = ({
+  children: _children,
+  disabled,
+  start,
+  href,
+  classBlock,
+  classModifiers: _classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classModifiers = [ ...toArray(_classModifiers), disabled ? 'disabled' : undefined, start ? 'start' : undefined ];
+  const classes = classBuilder(classBlock, classModifiers, className);
+  const children = (
+    <Fragment>
+      {_children}
+      {start && getStartIcon(classes)}
+    </Fragment>
+  );
+  if (isAnchor(href)) {
+    return getLinkButton({ children, href, classBlock, classModifiers, className, ...attrs });
+  }
+  return getButton({ children, disabled, className: classes(), ...attrs });
+};
+
+Button.propTypes = {
+  disabled: PropTypes.bool,
+  start: PropTypes.bool,
+  href: PropTypes.string,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Button.defaultProps = {
+  disabled: false,
+  start: false,
+  classBlock: DEFAULT_CLASS,
+  classModifiers: []
+};
+
+
+export const StartButton = ({ children, ...attrs }) => (
+  <Button {...attrs} start>{children}</Button>
+);
+
+StartButton.propTypes = {
+  children: PropTypes.node,
+  href: PropTypes.string.isRequired,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+StartButton.defaultProps = {
+  children: START_BUTTON_LABEL
+};
+
+export default Button;

--- a/packages/components/src/Button/Button.scss
+++ b/packages/components/src/Button/Button.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/button";

--- a/packages/components/src/Button/Button.stories.mdx
+++ b/packages/components/src/Button/Button.stories.mdx
@@ -1,0 +1,166 @@
+import { Meta, Props, Story, Canvas } from '@storybook/addon-docs';
+import Button, { StartButton } from './Button';
+import ButtonGroup from '../ButtonGroup';
+import Details from '../Details';
+import Link from '../Link';
+
+<Meta title="Button" id="D-Button" component={ Button } />
+
+# Button
+
+<Canvas withToolbar>
+  <Story name="Default">
+    <Button>Save and continue</Button>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ Button } />
+</Details>
+
+
+## When to use this component
+
+Use the button component to help users carry out an action like starting an
+application or saving their information.
+
+
+## How it works
+
+Write button text in sentence case, describing the action it performs. For
+example:
+
+- ‘Start now’ at the [start of the service]
+- ‘Sign in’ to an account a user has already created
+- ‘Continue’ when the service does not save a user’s information
+- ‘Save and continue’ when the service does save a user’s information
+- ‘Save and come back later’ when a user can save their information and come
+  back later
+- ‘Add another’ to add another item to a list or group
+- ‘Pay’ to make a payment
+- ‘Confirm and send’ on a [check answers] page that does not have any legal
+  content a user must agree to
+- ‘Accept and send’ on a [check answers] page that has legal content a user must
+  agree to
+- ‘Sign out’ when a user is signed in to an account
+
+You may need to include more or different words to better describe the action.
+For example, ‘Add another address’ and ‘Accept and claim a tax refund’.
+
+Align the primary action button to the left edge of your form.
+
+
+### Default buttons
+
+Use a default button for the main call to action on a page.
+
+Avoid using multiple default buttons on a single page. Having more than one main
+call to action reduces their impact, and makes it harder for users to know what
+to do next.
+
+<Canvas>
+  <Story name="Standard">
+    <Button>Save and continue</Button>
+  </Story>
+</Canvas>
+
+
+### Start buttons
+
+Use a start button for the main call to action on your service’s [start page].
+Start buttons do not submit form data, so they use a link tag rather than a
+button tag.
+
+<Canvas>
+  <Story name="Start">
+    <StartButton href="#" />
+  </Story>
+</Canvas>
+
+
+### Secondary buttons
+
+Use secondary buttons for secondary calls to action on a page.
+
+Pages with too many calls to action make it hard for users to know what to do
+next. Before adding lots of secondary buttons, try to simplify the page or break
+the content down across multiple pages.
+
+<Canvas>
+  <Story name="Secondary">
+    <Button classModifiers="secondary">Find address</Button>
+  </Story>
+</Canvas>
+
+You can also [group default and secondary buttons together].
+
+
+### Warning buttons
+
+Warning buttons are designed to make users think carefully before they use them.
+They only work if used very sparingly. Most services should not need one.
+
+<Canvas>
+  <Story name="Warning">
+    <Button classModifiers="warning">Delete account</Button>
+  </Story>
+</Canvas>
+
+Only use warning buttons for actions with serious destructive consequences that
+cannot be easily undone by a user. For example, permanently deleting an account.
+
+When letting users carry out an action like this, it’s a good idea to include an
+additional step which asks them to confirm it.
+
+In this instance, use another style of button for the initial call to action,
+and a warning button for the final confirmation.
+
+Do not only rely on the red colour of a warning button to communicate the
+serious nature of the action. This is because not all users will be able to see
+the colour or will understand what it signifies. Make sure the context and
+button text make clear what will happen if the user selects it.
+
+
+### Disabled buttons
+
+Disabled buttons have poor contrast and can confuse some users, so avoid them if
+possible.
+
+Only use disabled buttons if research shows it makes the user interface easier
+to understand.
+
+<Canvas>
+  <Story name="Disabled">
+    <Button disabled>Disabled button</Button>
+  </Story>
+</Canvas>
+
+
+### Grouping buttons
+
+Use a button group when two or more buttons are placed together.
+
+<Canvas>
+  <Story name="Group">
+    <ButtonGroup>
+      <Button>Save and continue</Button>
+      <Button classModifiers="secondary">Save as draft</Button>
+    </ButtonGroup>
+  </Story>
+</Canvas>
+
+Any links within a button group will automatically align with the buttons.
+
+<Canvas>
+  <Story name="Group with link">
+    <ButtonGroup>
+      <Button>Continue</Button>
+      <Link href="#">Cancel</Link>
+    </ButtonGroup>
+  </Story>
+</Canvas>
+
+[start of the service]: https://design-system.service.gov.uk/patterns/start-pages/
+[check answers]: https://design-system.service.gov.uk/patterns/check-answers/
+[start page]: https://design-system.service.gov.uk/patterns/start-pages/
+[group default and secondary buttons together]: https://design-system.service.gov.uk/components/button/#grouping-buttons

--- a/packages/components/src/Button/Button.test.js
+++ b/packages/components/src/Button/Button.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { fireEvent, getByTestId, render } from '@testing-library/react';
+import Button, { DEFAULT_CLASS, START_BUTTON_LABEL, StartButton } from './Button';
+import { DEFAULT_CLASS as LINK_DEFAULT_CLASS } from '../Link/Link';
+
+describe('Button', () => {
+
+  const checkSetup = (container, testId, dataModule = DEFAULT_CLASS) => {
+    const button = getByTestId(container, testId);
+    expect(button.classList).toContain(DEFAULT_CLASS);
+    expect(button.getAttribute('data-module')).toEqual(dataModule);
+    return button;
+  };
+
+  const checkIcon = (button) => {
+    const icon = button.childNodes[1];
+    expect(icon.tagName).toEqual('svg');
+    expect(icon.classList).toContain(`${DEFAULT_CLASS}__start-icon`);
+  };
+
+  it('should display the appropriate text in the button', async () => {
+    const BUTTON_ID = 'button';
+    const BUTTON_TEXT = 'Save and continue';
+    const { container } = render(
+      <Button data-testid={BUTTON_ID}>{BUTTON_TEXT}</Button>
+    );
+    const button = checkSetup(container, BUTTON_ID);
+    expect(button.innerHTML).toEqual(BUTTON_TEXT);
+    expect(button.tagName).toEqual('BUTTON');
+  });
+
+  it('should render as an anchor when an href is provided', async () => {
+    const BUTTON_ID = 'button';
+    const BUTTON_HREF = 'http://homeoffice.gov.uk/';
+    const BUTTON_TEXT = 'Save and continue';
+    const { container } = render(
+      <Button data-testid={BUTTON_ID} href={BUTTON_HREF}>{BUTTON_TEXT}</Button>
+    );
+    const button = checkSetup(container, BUTTON_ID, LINK_DEFAULT_CLASS);
+    expect(button.innerHTML).toEqual(BUTTON_TEXT);
+    expect(button.tagName).toEqual('A');
+    expect(button.href).toEqual(BUTTON_HREF);
+    expect(button.getAttribute('role')).toEqual('button');
+  });
+
+  it('should render a start button appropriately', async () => {
+    const BUTTON_ID = 'startButton';
+    const BUTTON_HREF = 'http://homeoffice.gov.uk/';
+    const { container } = render(
+      <StartButton data-testid={BUTTON_ID} href={BUTTON_HREF} />
+    );
+    const button = checkSetup(container, BUTTON_ID, LINK_DEFAULT_CLASS);
+    expect(button.classList).toContain(`${DEFAULT_CLASS}--start`);
+    expect(button.innerHTML).toContain(START_BUTTON_LABEL);
+    expect(button.tagName).toEqual('A');
+    expect(button.href).toEqual(BUTTON_HREF);
+    expect(button.getAttribute('role')).toEqual('button');
+    checkIcon(button);
+  });
+
+  it('should render a start icon when attribute is passed', async () => {
+    const BUTTON_ID = 'distinctStart';
+    const BUTTON_TEXT = 'Distinct start';
+    const { container } = render(
+      <Button data-testid={BUTTON_ID} start>{BUTTON_TEXT}</Button>
+    );
+    const button = checkSetup(container, BUTTON_ID);
+    expect(button.classList).toContain(`${DEFAULT_CLASS}--start`);
+    expect(button.innerHTML).toContain(BUTTON_TEXT);
+    expect(button.tagName).toEqual('BUTTON');
+    checkIcon(button);
+  });
+
+  it('should appropriately set up onClick handler', async () => {
+    const BUTTON_ID = 'distinctStart';
+    const BUTTON_TEXT = 'Distinct start';
+    let clicks = 0;
+    const ON_CLICK = (e) => {
+      clicks++;
+    };
+    const { container } = render(
+      <Button data-testid={BUTTON_ID} onClick={ON_CLICK}>{BUTTON_TEXT}</Button>
+    );
+    const button = checkSetup(container, BUTTON_ID);
+    expect(button.innerHTML).toContain(BUTTON_TEXT);
+    expect(button.tagName).toEqual('BUTTON');
+    expect(clicks).toEqual(0);
+    fireEvent.click(button, {});
+    expect(clicks).toEqual(1);
+  });
+
+  it('should appropriately disable the button', async () => {
+    const BUTTON_ID = 'distinctStart';
+    const BUTTON_TEXT = 'Distinct start';
+    let clicks = 0;
+    const ON_CLICK = (e) => {
+      clicks++;
+    };
+    const { container } = render(
+      <Button data-testid={BUTTON_ID} onClick={ON_CLICK} disabled>{BUTTON_TEXT}</Button>
+    );
+    const button = checkSetup(container, BUTTON_ID);
+    expect(button.classList).toContain(`${DEFAULT_CLASS}--disabled`);
+    expect(button.disabled).toEqual(true);
+    expect(button.getAttribute('aria-disabled')).toEqual('true');
+    expect(button.innerHTML).toContain(BUTTON_TEXT);
+    expect(button.tagName).toEqual('BUTTON');
+    expect(clicks).toEqual(0);
+    fireEvent.click(button, {});
+    expect(clicks).toEqual(0);
+  });
+
+});

--- a/packages/components/src/Button/index.js
+++ b/packages/components/src/Button/index.js
@@ -1,0 +1,6 @@
+import Button, { StartButton } from './Button';
+
+export default Button;
+export {
+  StartButton
+};

--- a/packages/components/src/ButtonGroup/ButtonGroup.jsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './ButtonGroup.scss';
+
+export const DEFAULT_CLASS = 'govuk-button-group';
+export const ButtonGroup = ({
+  children,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+
+  return <div {...attrs} className={classes()}>
+    {children}
+  </div>;
+};
+
+ButtonGroup.propTypes = {
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+ButtonGroup.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default ButtonGroup;

--- a/packages/components/src/ButtonGroup/ButtonGroup.scss
+++ b/packages/components/src/ButtonGroup/ButtonGroup.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "govuk-frontend/govuk/objects/_button-group";

--- a/packages/components/src/ButtonGroup/ButtonGroup.stories.mdx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.stories.mdx
@@ -1,0 +1,70 @@
+import { Meta, Props, Story, Canvas } from '@storybook/addon-docs';
+import Button from '../Button';
+import Details from '../Details';
+import Link from '../Link';
+import ButtonGroup from './ButtonGroup';
+import './ButtonGroup.stories.scss';
+
+<Meta title="Button group" id="D-ButtonGroup" component={ ButtonGroup } />
+
+# Button group
+
+<p><strong className="govuk-tag">Internal</strong></p>
+
+A component for grouping buttons and links on a single line.
+
+<Canvas withToolbar>
+  <Story name="Default">
+    <ButtonGroup>
+      <Button>Save and continue</Button>
+      <Button classModifiers="secondary">Save as draft</Button>
+    </ButtonGroup>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ ButtonGroup } />
+</Details>
+
+
+## Stories
+### Buttons
+
+A standard Button group.
+
+<Canvas>
+  <Story name="Buttons">
+    <ButtonGroup>
+      <Button>Save and continue</Button>
+      <Button classModifiers="secondary">Save as draft</Button>
+    </ButtonGroup>
+  </Story>
+</Canvas>
+
+### Links
+
+A group of Links.
+
+<Canvas>
+  <Story name="Links">
+    <ButtonGroup>
+      <Link href="#">One</Link>
+      <Link href="#">Two</Link>
+      <Link href="#">Three</Link>
+    </ButtonGroup>
+  </Story>
+</Canvas>
+
+### Buttons and links
+
+A mixture of Buttons and Links.
+
+<Canvas>
+  <Story name="Mixture">
+    <ButtonGroup>
+      <Button>Save and continue</Button>
+      <Button classModifiers="secondary">Save as draft</Button>
+      <Link href="#">Cancel</Link>
+    </ButtonGroup>
+  </Story>
+</Canvas>

--- a/packages/components/src/ButtonGroup/ButtonGroup.stories.scss
+++ b/packages/components/src/ButtonGroup/ButtonGroup.stories.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/tag/_index";

--- a/packages/components/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/components/src/ButtonGroup/ButtonGroup.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Button from '../Button';
+import ButtonGroup, { DEFAULT_CLASS } from './ButtonGroup';
+import Link from '../Link';
+
+describe('ButtonGroup', () => {
+
+  const checkSetup = (container, testId) => {
+    const buttonGroup = getByTestId(container, testId);
+    expect(buttonGroup.classList).toContain(DEFAULT_CLASS);
+    return buttonGroup;
+  };
+
+  it('should handle button children appropriately', async () => {
+    const GROUP_ID = 'buttonGroup';
+    const BUTTON_LABELS = ['Save and continue', 'Save as draft'];
+    const { container } = render(
+      <ButtonGroup data-testid={GROUP_ID}>
+        {BUTTON_LABELS.map(label => (
+          <Button key={label}>{label}</Button>
+        ))}
+      </ButtonGroup>
+    );
+    const buttonGroup = checkSetup(container, GROUP_ID);
+    expect(buttonGroup.childNodes.length).toEqual(BUTTON_LABELS.length);
+    BUTTON_LABELS.forEach((label, index) => {
+      const button = buttonGroup.childNodes[index];
+      expect(button.innerHTML).toEqual(label);
+      expect(button.tagName).toEqual('BUTTON');
+    });
+  });
+
+  it('should handle link children appropriately', async () => {
+    const GROUP_ID = 'buttonGroup';
+    const LINK_LABELS = ['Save and continue', 'Save as draft'];
+    const { container } = render(
+      <ButtonGroup data-testid={GROUP_ID}>
+        {LINK_LABELS.map(label => (
+          <Button key={label} href="#">{label}</Button>
+        ))}
+      </ButtonGroup>
+    );
+    const buttonGroup = checkSetup(container, GROUP_ID);
+    expect(buttonGroup.childNodes.length).toEqual(LINK_LABELS.length);
+    LINK_LABELS.forEach((label, index) => {
+      const link = buttonGroup.childNodes[index];
+      expect(link.innerHTML).toEqual(label);
+      expect(link.tagName).toEqual('A');
+    });
+  });
+
+  it('should handle a mixture of buttons and links appropriately', async () => {
+    const GROUP_ID = 'buttonGroup';
+    const FIRST_CHILD = <Button>Save and continue</Button>;
+    const SECOND_CHILD = <Button classModifiers="secondary">Save as draft</Button>;
+    const THIRD_LINK = <Link href="#">Cancel</Link>;
+    const { container } = render(
+      <ButtonGroup data-testid={GROUP_ID}>
+        {FIRST_CHILD}
+        {SECOND_CHILD}
+        {THIRD_LINK}
+      </ButtonGroup>
+    );
+    const buttonGroup = checkSetup(container, GROUP_ID);
+    expect(buttonGroup.childNodes.length).toEqual(3);
+    expect(buttonGroup.childNodes[0].innerHTML).toEqual('Save and continue');
+    expect(buttonGroup.childNodes[0].tagName).toEqual('BUTTON');
+    expect(buttonGroup.childNodes[1].innerHTML).toEqual('Save as draft');
+    expect(buttonGroup.childNodes[1].tagName).toEqual('BUTTON');
+    expect(buttonGroup.childNodes[2].innerHTML).toEqual('Cancel');
+    expect(buttonGroup.childNodes[2].tagName).toEqual('A');
+  });
+
+});

--- a/packages/components/src/ButtonGroup/index.js
+++ b/packages/components/src/ButtonGroup/index.js
@@ -1,0 +1,3 @@
+import ButtonGroup from './ButtonGroup';
+
+export default ButtonGroup;

--- a/packages/components/src/Link/Link.jsx
+++ b/packages/components/src/Link/Link.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classBuilder } from '../utils/Utils';
+import './Link.scss';
+
+export const DEFAULT_CLASS = 'govuk-link';
+export const Link = ({
+  children,
+  href,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return <a data-module={DEFAULT_CLASS} href={href} {...attrs} className={classes()}>
+    {children}
+  </a>;
+};
+
+Link.propTypes = {
+  href: PropTypes.string,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Link.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Link;

--- a/packages/components/src/Link/Link.scss
+++ b/packages/components/src/Link/Link.scss
@@ -1,0 +1,6 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/core/_links";
+
+a {
+  @extend .govuk-link
+}

--- a/packages/components/src/Link/Link.test.js
+++ b/packages/components/src/Link/Link.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Link, { DEFAULT_CLASS } from './Link';
+
+describe('Link', () => {
+
+  const checkSetup = (container, testId) => {
+    const link = getByTestId(container, testId);
+    expect(link.classList).toContain(DEFAULT_CLASS);
+    expect(link.getAttribute('data-module')).toEqual(DEFAULT_CLASS);
+    return link;
+  };
+
+  it('should display the appropriate text in the link and have the correct href', async () => {
+    const LINK_ID = 'link';
+    const LINK_HREF = 'http://homeoffice.gov.uk/';
+    const LINK_TEXT = `Here's some important information for you`;
+    const { container } = render(
+      <Link data-testid={LINK_ID} href={LINK_HREF}>{LINK_TEXT}</Link>
+    );
+    const link = checkSetup(container, LINK_ID);
+    expect(link.innerHTML).toEqual(LINK_TEXT);
+    expect(link.href).toEqual(LINK_HREF);
+  });
+
+  it('should appropriately support classModifiers', async () => {
+    const LINK_ID = 'link';
+    const LINK_HREF = 'http://homeoffice.gov.uk/';
+    const LINK_TEXT = `Here's some important information for you`;
+    const CLASS_MODIFIERS = ['warning', 'test'];
+    const { container } = render(
+      <Link data-testid={LINK_ID} href={LINK_HREF} classModifiers={CLASS_MODIFIERS}>{LINK_TEXT}</Link>
+    );
+    const link = checkSetup(container, LINK_ID);
+    expect(link.innerHTML).toEqual(LINK_TEXT);
+    expect(link.href).toEqual(LINK_HREF);
+    CLASS_MODIFIERS.forEach(cm => {
+      expect(link.classList).toContain(`${DEFAULT_CLASS}--${cm}`);
+    });
+  });
+
+  it('should appropriately support an additional role attribute', async () => {
+    const LINK_ID = 'link';
+    const LINK_HREF = 'http://homeoffice.gov.uk/';
+    const LINK_TEXT = `Here's some important information for you`;
+    const LINK_ROLE = 'button';
+    const { container } = render(
+      <Link data-testid={LINK_ID} href={LINK_HREF} role={LINK_ROLE}>{LINK_TEXT}</Link>
+    );
+    const link = checkSetup(container, LINK_ID);
+    expect(link.innerHTML).toEqual(LINK_TEXT);
+    expect(link.href).toEqual(LINK_HREF);
+    expect(link.getAttribute('role')).toEqual(LINK_ROLE);
+  });
+
+});

--- a/packages/components/src/Link/index.js
+++ b/packages/components/src/Link/index.js
@@ -1,0 +1,3 @@
+import Link from './Link';
+
+export default Link;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,4 +1,6 @@
 import Alert from './Alert';
+import Button, { StartButton } from './Button';
+import ButtonGroup from './ButtonGroup';
 import Details from './Details';
 import ErrorMessage from './ErrorMessage';
 import Hint from './Hint';
@@ -13,6 +15,8 @@ import VisuallyHidden from './VisuallyHidden';
 
 export {
   Alert,
+  Button,
+  ButtonGroup,
   Details,
   ErrorMessage,
   Hint,
@@ -20,6 +24,7 @@ export {
   Label,
   Link,
   Panel,
+  StartButton,
   Tag,
   TextInput,
   Utils,

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -4,6 +4,7 @@ import ErrorMessage from './ErrorMessage';
 import Hint from './Hint';
 import InsetText from './InsetText';
 import Label from './Label';
+import Link from './Link';
 import Panel from './Panel';
 import Tag from './Tag';
 import TextInput from './TextInput';
@@ -17,6 +18,7 @@ export {
   Hint,
   InsetText,
   Label,
+  Link,
   Panel,
   Tag,
   TextInput,


### PR DESCRIPTION
### Description
Added the `Button` and `ButtonGroup` components, as well as a basic `Link` component, along with unit tests and Storybook stories.

### Important
This PR depends on the following PRs and should be rebased against `master` before it eventually gets merged:
* https://github.com/UKHomeOffice/cop-react-design-system/pull/3
  * https://github.com/UKHomeOffice/cop-react-design-system/pull/4

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`