### PR TITLE
COP-9143: Add FormGroup component

### DIFF
--- a/packages/components/src/FormGroup/FormGroup.jsx
+++ b/packages/components/src/FormGroup/FormGroup.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ErrorMessage from '../ErrorMessage';
+import Hint from '../Hint';
+import Label from '../Label';
+import { classBuilder, toArray } from '../utils/Utils';
+import './FormGroup.scss';
+
+export const DEFAULT_CLASS = 'govuk-form-group';
+const FormGroup = ({
+  children,
+  id,
+  label,
+  hint,
+  error,
+  required,
+  classBlock,
+  classModifiers: _classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classModifiers = [...toArray(_classModifiers), error ? 'error' : undefined ];
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return (
+    <div {...attrs} key={id} className={classes()}>
+      <Label id={id} required={required}>{label}</Label>
+      {hint && <Hint id={id}>{hint}</Hint>}
+      {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
+      {children}
+    </div>
+  );
+};
+
+FormGroup.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
+  hint: PropTypes.node,
+  error: PropTypes.node,
+  required: PropTypes.bool,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+FormGroup.defaultProps = {
+  required: false,
+  classBlock: DEFAULT_CLASS,
+  classModifiers: []
+};
+
+FormGroup.displayName = 'FormGroup';
+
+export default FormGroup;

--- a/packages/components/src/FormGroup/FormGroup.scss
+++ b/packages/components/src/FormGroup/FormGroup.scss
@@ -1,0 +1,3 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/objects/_form-group";
+@import "node_modules/govuk-frontend/govuk/utilities/_visually-hidden";

--- a/packages/components/src/FormGroup/FormGroup.stories.mdx
+++ b/packages/components/src/FormGroup/FormGroup.stories.mdx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { Canvas, Meta, Props, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import FormGroup from './FormGroup';
+import Tag from '../Tag';
+import TextInput from '../TextInput';
+
+<Meta title="Internal/Form group" component={ FormGroup } />
+
+# Form group
+
+<p><Tag text="Internal" /></p>
+
+A group of form fields.
+
+<Canvas>
+  <Story name="Default">
+    <FormGroup id="formGroup" label="Basic form group">
+      <input type="text" className="govuk-input" />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <Props of={ FormGroup } />
+</Details>
+
+# Variants
+## Optional
+
+An optional form group, which tracks changes as you type.
+
+<Canvas>
+  <Story name="Optional">
+    {() => {
+      const [value, setValue] = useState({});
+      const [changes, setChanges] = useState([]);
+      const onChange = ({ target }) => {
+        setValue(prev => {
+          const next = { ...prev, [target.name]: target.value };
+          setChanges(prevChanges => {
+            return [...prevChanges, { ts: Date.now(), value: next }];
+          });
+          return next;
+        });
+      };
+      const fieldId = 'textFieldOptional';
+      const groupOptions = {
+        id: 'idOptional',
+        label: 'Optional text field'
+      };
+      const componentOptions = {
+        ...groupOptions,
+        fieldId,
+        type: 'text',
+        value: value[fieldId] || '',
+        onChange
+      };
+      return (
+        <>
+          <FormGroup {...groupOptions}>
+            <TextInput {...componentOptions} />
+          </FormGroup>
+          {changes && 
+            <Details summary="Change series" className="no-indent">
+              <ol>
+                {changes && changes.map(change => (
+                  <li key={change.ts}>{JSON.stringify(change.value)}</li>
+                ))}
+              </ol>
+            </Details>
+          }
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Required
+
+A required form group, with hint text.
+
+<Canvas>
+  <Story name="Required">
+    {() => {
+      const [value, setValue] = useState({});
+      const onChange = ({ target }) => {
+        setValue(prev => {
+          return { ...prev, [target.name]: target.value };
+        });
+      };
+      const fieldId = 'textFieldRequired';
+      const groupOptions = {
+        id: 'idRequired',
+        label: 'Mandatory text field',
+        hint: 'Hint: This field is required',
+        required: true
+      };
+      const componentOptions = {
+        ...groupOptions,
+        fieldId,
+        type: 'text',
+        value: value[fieldId] || '',
+        onChange
+      };
+      return <FormGroup {...groupOptions}>
+        <TextInput {...componentOptions} />
+      </FormGroup>;
+    }}
+  </Story>
+</Canvas>
+
+## Error
+
+A required form group, with hint text, that will show an error when it is empty.
+
+<Canvas>
+  <Story name="Error">
+    {() => {
+      const ERROR_MESSAGE = 'Mandatory text field is required';
+      const [value, setValue] = useState({});
+      const [error, setError] = useState(ERROR_MESSAGE);
+      const onChange = ({ target }) => {
+        setValue(prev => {
+          setError(target.value ? undefined : ERROR_MESSAGE);
+          return { ...prev, [target.name]: target.value };
+        });
+      };
+      const fieldId = 'textFieldError';
+      const groupOptions = {
+        id: 'idRequired',
+        label: 'Mandatory text field',
+        hint: <span>This field will <strong>only</strong> show an error message if it is left blank</span>,
+        required: true,
+        error
+      };
+      const componentOptions = {
+        ...groupOptions,
+        fieldId,
+        type: 'text',
+        value: value[fieldId] || '',
+        onChange
+      };
+      return <FormGroup {...groupOptions}>
+        <TextInput {...componentOptions} />
+      </FormGroup>;
+    }}
+  </Story>
+</Canvas>

--- a/packages/components/src/FormGroup/FormGroup.test.js
+++ b/packages/components/src/FormGroup/FormGroup.test.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import FormGroup, { DEFAULT_CLASS } from './FormGroup';
+
+describe('FormGroup', () => {
+
+  const checkSetup = (container, testId) => {
+    const formGroup = getByTestId(container, testId);
+    expect(formGroup.classList).toContain(DEFAULT_CLASS);
+    expect(formGroup.tagName).toEqual('DIV');
+    return formGroup;
+  };
+
+  it('should appropriately set up a minimal form group', async () => {
+    const OPTIONS = {
+      id: 'fieldId',
+      label: 'Field label'
+    };
+    const CHILD_ID = 'child';
+    const { container } = render(
+      <FormGroup data-testid={OPTIONS.id} {...OPTIONS}>
+        <input data-testid={CHILD_ID} type="text" />
+      </FormGroup>
+    );
+    const formGroup = checkSetup(container, OPTIONS.id);
+    expect(formGroup.classList).not.toContain(`${DEFAULT_CLASS}--error`);
+    const input = getByTestId(formGroup, CHILD_ID);
+    expect(input.type).toEqual('text');
+    const label = formGroup.childNodes[0];
+    expect(label.getAttribute('for')).toEqual(OPTIONS.id);
+    expect(label.innerHTML).toEqual(`${OPTIONS.label} (optional)`); // This is an optional field so should include the suffix
+    expect(formGroup.children.length).toEqual(2); // Just the label and input
+  });
+
+  it('should appropriately set up a required form group', async () => {
+    const OPTIONS = {
+      id: 'fieldId',
+      label: 'Field label',
+      required: true
+    };
+    const CHILD_ID = 'child';
+    const { container } = render(
+      <FormGroup data-testid={OPTIONS.id} {...OPTIONS}>
+        <input data-testid={CHILD_ID} type="text" />
+      </FormGroup>
+    );
+    const formGroup = checkSetup(container, OPTIONS.id);
+    expect(formGroup.classList).not.toContain(`${DEFAULT_CLASS}--error`);
+    const input = getByTestId(formGroup, CHILD_ID);
+    expect(input.type).toEqual('text');
+    const label = formGroup.childNodes[0];
+    expect(label.getAttribute('for')).toEqual(OPTIONS.id);
+    expect(label.innerHTML).toEqual(OPTIONS.label); // This is a required field so should NOT include the suffix
+    expect(formGroup.children.length).toEqual(2); // Just the label and input
+  });
+
+  it('should include a hint where specified', async () => {
+    const OPTIONS = {
+      id: 'fieldId',
+      label: 'Field label',
+      required: true,
+      hint: 'This field needs to be completed.'
+    };
+    const CHILD_ID = 'child';
+    const { container } = render(
+      <FormGroup data-testid={OPTIONS.id} {...OPTIONS}>
+        <input data-testid={CHILD_ID} type="text" />
+      </FormGroup>
+    );
+    const formGroup = checkSetup(container, OPTIONS.id);
+    expect(formGroup.classList).not.toContain(`${DEFAULT_CLASS}--error`);
+    const input = getByTestId(formGroup, CHILD_ID);
+    expect(input.type).toEqual('text');
+    const label = formGroup.childNodes[0];
+    expect(label.getAttribute('for')).toEqual(OPTIONS.id);
+    expect(label.innerHTML).toEqual(OPTIONS.label); // This is a required field so should NOT include the suffix
+    const hint = formGroup.childNodes[1]; // Second child.
+    expect(hint.innerHTML).toEqual(OPTIONS.hint);
+    expect(formGroup.children.length).toEqual(3); // The label, the hint, and input
+  });
+
+  it('should include an error where specified', async () => {
+    const OPTIONS = {
+      id: 'fieldId',
+      label: 'Field label',
+      required: true,
+      error: 'Field label is required'
+    };
+    const CHILD_ID = 'child';
+    const { container } = render(
+      <FormGroup data-testid={OPTIONS.id} {...OPTIONS}>
+        <input data-testid={CHILD_ID} type="text" />
+      </FormGroup>
+    );
+    const formGroup = checkSetup(container, OPTIONS.id);
+    expect(formGroup.classList).toContain(`${DEFAULT_CLASS}--error`);
+    const input = getByTestId(formGroup, CHILD_ID);
+    expect(input.type).toEqual('text');
+    const label = formGroup.childNodes[0];
+    expect(label.getAttribute('for')).toEqual(OPTIONS.id);
+    expect(label.innerHTML).toEqual(OPTIONS.label); // This is a required field so should NOT include the suffix
+    const error = formGroup.childNodes[1]; // Second child.
+    expect(error.innerHTML).toContain('Error:'); // Visually-hidden
+    expect(error.innerHTML).toContain(OPTIONS.error);
+    expect(formGroup.children.length).toEqual(3); // The label, the error, and input
+  });
+
+  it('should include a hint and an error where specified', async () => {
+    const OPTIONS = {
+      id: 'fieldId',
+      label: 'Field label',
+      required: true,
+      hint: 'This field needs to be completed.',
+      error: 'Field label is required'
+    };
+    const CHILD_ID = 'child';
+    const { container } = render(
+      <FormGroup data-testid={OPTIONS.id} {...OPTIONS}>
+        <input data-testid={CHILD_ID} type="text" />
+      </FormGroup>
+    );
+    const formGroup = checkSetup(container, OPTIONS.id);
+    expect(formGroup.classList).toContain(`${DEFAULT_CLASS}--error`);
+    const input = getByTestId(formGroup, CHILD_ID);
+    expect(input.type).toEqual('text');
+    const label = formGroup.childNodes[0];
+    expect(label.getAttribute('for')).toEqual(OPTIONS.id);
+    expect(label.innerHTML).toEqual(OPTIONS.label); // This is a required field so should NOT include the suffix
+    const hint = formGroup.childNodes[1]; // Second child.
+    expect(hint.innerHTML).toEqual(OPTIONS.hint);
+    const error = formGroup.childNodes[2]; // Third child.
+    expect(error.innerHTML).toContain('Error:'); // Visually-hidden
+    expect(error.innerHTML).toContain(OPTIONS.error);
+    expect(formGroup.children.length).toEqual(4); // All of the possible components
+  });
+
+});

--- a/packages/components/src/FormGroup/index.js
+++ b/packages/components/src/FormGroup/index.js
@@ -1,0 +1,3 @@
+import FormGroup from './FormGroup';
+
+export default FormGroup;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -2,6 +2,7 @@ import Alert from './Alert';
 import Button, { StartButton } from './Button';
 import ButtonGroup from './ButtonGroup';
 import Details from './Details';
+import FormGroup from './FormGroup';
 import ErrorMessage from './ErrorMessage';
 import Hint from './Hint';
 import InsetText from './InsetText';
@@ -19,6 +20,7 @@ export {
   ButtonGroup,
   Details,
   ErrorMessage,
+  FormGroup,
   Hint,
   InsetText,
   Label,


### PR DESCRIPTION
### Description
Added the `FormGroup` component, along with unit tests and Storybook stories.

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`