### PR TITLE
COP-9233: Override immer version

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,6 +48,9 @@
     "babel-loader": "8.1.0",
     "webpack": "4.44.2"
   },
+  "resolutions": {
+    "immer": "9.0.6"
+  },
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -8052,10 +8052,10 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+immer@8.0.1, immer@9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
### Description
Added a resolution to `package.json` for `immer` version `9.0.6`. Since this uses yarn for compilation, it should simply work.

### To test
As described, this addresses a security issue with versions of `immer` earlier than `9.0.6`. This should now build and deploy correctly without the npm audit failing.