### PR TITLE
COP-8968: Add Radios component

### DIFF
--- a/packages/components/src/Radios/Radio.jsx
+++ b/packages/components/src/Radios/Radio.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import Hint, { DEFAULT_CLASS as DEFAULT_HINT_CLASS } from '../Hint/Hint';
+import { DEFAULT_CLASS as DEFAULT_LABEL_CLASS } from '../Label/Label';
+import { classBuilder } from '../utils/Utils';
+import './Radios.scss';
+
+export const DEFAULT_CLASS = 'govuk-radios';
+const Radio = ({
+  id,
+  name,
+  option,
+  selected,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  const inputRef = useRef(null);
+  /**
+   * This is needed for externally setting the selected state.
+   * Without this mechanism, we need to have the component fully
+   * controlled with both checked and onChange attributes and its
+   * state will be managed entirely externally.
+   */
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.checked = selected;
+    }
+  }, [inputRef, selected]);
+  return (
+    <div className={classes('item')} {...attrs}>
+      <input
+        ref={inputRef}
+        className={classes('input')}
+        id={id}
+        name={name}
+        type="radio"
+        value={option.value}
+        disabled={option.disabled}
+      />
+      <label className={`${DEFAULT_LABEL_CLASS} ${classes('label')}`} htmlFor={id} disabled={option.disabled}>{option.label}</label>
+      {option.hint && <Hint id={`${id}-hint`} className={`${DEFAULT_HINT_CLASS} ${classes('hint')}`}>{option.hint}</Hint>}
+    </div>
+  );
+};
+
+Radio.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  option: PropTypes.oneOfType([
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      hint: PropTypes.string,
+      disabled: PropTypes.bool
+    }),
+    PropTypes.string
+  ]).isRequired,
+  selected: PropTypes.bool,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Radio.defaultProps = {
+  selected: false,
+  classBlock: DEFAULT_CLASS
+};
+
+export default Radio;

--- a/packages/components/src/Radios/Radio.jsx
+++ b/packages/components/src/Radios/Radio.jsx
@@ -1,5 +1,8 @@
+// Global imports
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+
+// Local imports
 import Hint, { DEFAULT_CLASS as DEFAULT_HINT_CLASS } from '../Hint/Hint';
 import { DEFAULT_CLASS as DEFAULT_LABEL_CLASS } from '../Label/Label';
 import { classBuilder } from '../utils/Utils';

--- a/packages/components/src/Radios/Radio.test.js
+++ b/packages/components/src/Radios/Radio.test.js
@@ -1,6 +1,8 @@
-
+// Global imports
 import React from 'react';
 import { getByTestId, render } from '@testing-library/react';
+
+// Local imports
 import Radio, { DEFAULT_CLASS } from './Radio';
 
 describe('Radio', () => {

--- a/packages/components/src/Radios/Radio.test.js
+++ b/packages/components/src/Radios/Radio.test.js
@@ -1,0 +1,111 @@
+
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+import Radio, { DEFAULT_CLASS } from './Radio';
+
+describe('Radio', () => {
+
+  const checkSetup = (container, testId) => {
+    const wrapper = getByTestId(container, testId);
+    expect(wrapper.classList).toContain(`${DEFAULT_CLASS}__item`);
+    const input = wrapper.childNodes[0];
+    const label = wrapper.childNodes[1];
+    const hint = wrapper.childNodes[2];
+    return { wrapper, input, label, hint };
+  };
+
+  it('should appropriately set up the necessary components', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'radioFieldId';
+    const OPTION = { value: 'england', label: 'England' };
+    const { container } = render(
+      <Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} />
+    );
+    const { input, label, hint } = checkSetup(container, ID);
+    // Input
+    expect(input.tagName).toEqual('INPUT');
+    expect(input.type).toEqual('radio');
+    expect(input.id).toEqual(ID);
+    expect(input.name).toEqual(FIELD_ID);
+    expect(input.value).toEqual(OPTION.value);
+    expect(input.classList).toContain(`${DEFAULT_CLASS}__input`);
+    expect(input.getAttribute('disabled')).toBeNull();
+    // Label
+    expect(label.classList).toContain(`${DEFAULT_CLASS}__label`);
+    expect(label.innerHTML).toEqual(OPTION.label);
+    expect(label.getAttribute('for')).toEqual(ID);
+    expect(label.getAttribute('disabled')).toBeNull();
+    // No hint
+    expect(hint).toBeUndefined();
+  });
+
+  it('should appropriately set up the necessary components with a hint', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'radioFieldId';
+    const OPTION = { value: 'england', label: 'England', hint: 'This is a hint' };
+    const { container } = render(
+      <Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} />
+    );
+    const { input, label, hint } = checkSetup(container, ID);
+    // Input
+    expect(input).toBeDefined();
+    // Label
+    expect(label).toBeDefined();
+    // No hint
+    expect(hint).toBeDefined();
+    expect(hint.classList).toContain(`${DEFAULT_CLASS}__hint`);
+    expect(hint.innerHTML).toEqual(OPTION.hint);
+    expect(hint.id).toEqual(`${ID}-hint`);
+  });
+
+  it('should not be checked by default', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'radioFieldId';
+    const OPTION = { value: 'england', label: 'England' };
+    const { container } = render(
+      <Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} />
+    );
+    const { input } = checkSetup(container, ID);
+    expect(input.checked).toEqual(false);
+  });
+
+  it('should not be checked when selected is set to false', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'radioFieldId';
+    const OPTION = { value: 'england', label: 'England' };
+    const { container } = render(
+      <Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} selected={false} />
+    );
+    const { input } = checkSetup(container, ID);
+    expect(input.checked).toEqual(false);
+  });
+
+  it('should be checked when selected is set to true', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'radioFieldId';
+    const OPTION = { value: 'england', label: 'England' };
+    const { container } = render(
+      <Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} selected={true} />
+    );
+    const { input } = checkSetup(container, ID);
+    expect(input.checked).toEqual(true);
+  });
+
+  it('should toggle checked when selected changes value', async () => {
+    const ID = 'radio';
+    const FIELD_ID = 'radioFieldId';
+    const OPTION = { value: 'england', label: 'England' };
+    const { container, rerender } = render(
+      <Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} />
+    );
+    const { input } = checkSetup(container, ID);
+    expect(input.checked).toEqual(false);
+    // Use re-render to pass a new selected value.
+    rerender(<Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} selected={true} />);
+    expect(input.checked).toEqual(true);
+    // And toggle it back to false.
+    rerender(<Radio data-testid={ID} id={ID} name={FIELD_ID} option={OPTION} selected={false} />);
+    expect(input.checked).toEqual(false);
+  });
+
+});

--- a/packages/components/src/Radios/Radios.jsx
+++ b/packages/components/src/Radios/Radios.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Radio from './Radio';
+import { classBuilder } from '../utils/Utils';
+import './Radios.scss';
+
+export const DEFAULT_CLASS = 'govuk-radios';
+const Radios = ({
+  id,
+  fieldId,
+  options,
+  value,
+  onChange,
+  classBlock,
+  classModifiers,
+  className,
+  ...attrs
+}) => {
+  const classes = classBuilder(classBlock, classModifiers, className);
+  return (
+    <div id={id} className={classes()} onChange={onChange} {...attrs}>
+      {options && options.map((option, index) => {
+        const optionId = `${fieldId}-${index}`;
+        if (typeof option === 'string') {
+          return <div className={classes('divider')} key={optionId}>{option}</div>
+        } else {
+          const name = fieldId;
+          const selected = typeof(value) === 'object' ? (option.value === value?.value) : (option.value === value);
+          return (
+            <Radio
+              key={optionId}
+              id={optionId}
+              name={name}
+              option={option}
+              selected={selected}
+              classBlock={classBlock}
+              classModifiers={classModifiers}
+              className={className} />
+          );
+        }
+      })}
+    </div>
+  );
+};
+
+Radios.propTypes = {
+  id: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        value: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        hint: PropTypes.string,
+        disabled: PropTypes.bool
+      }),
+      PropTypes.string
+    ])
+  ).isRequired,
+  value: PropTypes.any,
+  onChange: PropTypes.func,
+  classBlock: PropTypes.string,
+  classModifiers: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  className: PropTypes.string
+};
+
+Radios.defaultProps = {
+  classBlock: DEFAULT_CLASS
+};
+
+export default Radios;

--- a/packages/components/src/Radios/Radios.jsx
+++ b/packages/components/src/Radios/Radios.jsx
@@ -1,5 +1,8 @@
+// Global imports
 import React from 'react';
 import PropTypes from 'prop-types';
+
+// Local imports
 import Radio from './Radio';
 import { classBuilder } from '../utils/Utils';
 import './Radios.scss';

--- a/packages/components/src/Radios/Radios.scss
+++ b/packages/components/src/Radios/Radios.scss
@@ -1,0 +1,2 @@
+@import "node_modules/govuk-frontend/govuk/_base";
+@import "node_modules/govuk-frontend/govuk/components/radios";

--- a/packages/components/src/Radios/Radios.stories.mdx
+++ b/packages/components/src/Radios/Radios.stories.mdx
@@ -1,0 +1,419 @@
+import { useState } from 'react';
+import { Canvas, Meta, ArgsTable, Story } from '@storybook/addon-docs';
+import Details from '../Details';
+import FormGroup from '../FormGroup';
+import Radios from './Radios';
+
+<Meta
+  id="D-Radios"
+  title="Radios"
+  component={ Radios }
+/>
+
+# Radios
+
+<Canvas withToolbar>
+  <Story name="Radios">
+    {() => {
+      const OPTIONS = [
+        { value: 'england', label: 'England' },
+        { value: 'scotland', label: 'Scotland' },
+        { value: 'wales', label: 'Wales' },
+        { value: 'northern-ireland', label: 'Northern Ireland' }
+      ];
+      return (
+        <FormGroup
+          id="radios"
+          label={<h1 className="govuk-heading-l">Where do you live?</h1>}>
+          <Radios
+            id="radios"
+            fieldId="where-do-you-live-radios"
+            options={OPTIONS}
+          />
+        </FormGroup>
+      );
+    }}
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ Radios } />
+</Details>
+
+
+## When to use this component
+
+Use the radios component when users can only select one option from a list.
+
+
+## When not to use this component
+
+Do not use the radios component if users might need to select more than one
+option. In this case, you should use the checkboxes component instead.
+
+
+## How it works
+
+Radios are grouped together in a `<fieldset>` with a `<legend>` that describes
+them, as shown in the examples on this page. This is usually a question, like
+‘Where do you live?’.
+
+If you are asking just one question per page as recommended, you can set the
+contents of the `<legend>` as the page heading. This is good practice as it
+means that users of screen readers will only hear the contents once.
+
+Read more about why and how to set legends as headings.
+
+Always position radios to the left of their labels. This makes them easier to
+find, especially for users of screen magnifiers.
+
+Unlike with checkboxes, users can only select one option from a list of radios.
+Do not assume that users will know how many options they can select based on the
+visual difference between radios and checkboxes alone.
+
+If needed, add a hint explaining this, for example, ‘Select one option’.
+
+Do not pre-select radio options as this makes it more likely that users will:
+
+- not realise they’ve missed a question
+- submit the wrong answer
+
+Users cannot go back to having no option selected once they have selected one,
+without refreshing their browser window. Therefore, you should include ‘None of
+the above’ or ‘I do not know’ if they are valid options.
+
+Order radio options alphabetically by default.
+
+In some cases, it can be helpful to order them from most-to-least common
+options. For example, you could order options for ‘Where do you live?’ based on
+population size.
+
+However you should do this with extreme caution as it can reinforce bias in your
+service. If in doubt, order alphabetically.
+
+Group radios together in a `<fieldset>` with a `<legend>` that describes them,
+as shown in the examples on this page. This is usually a question, like ‘Where
+do you live?’.
+
+
+### If you’re asking one question on the page
+
+If you’re asking just [one question per page] as recommended, you can set the
+contents of the `<legend>` as the page heading. This is good practice as it
+means that users of screen readers will only hear the contents once.
+
+Read more about [why and how to set legends as headings].
+
+<Canvas>
+  <Story name="Standard">
+    <FormGroup
+      id="standard"
+      label={<h1 className="govuk-heading-l">Where do you live?</h1>}>
+      <Radios
+        id="standard"
+        fieldId="where-do-you-live-standard"
+        options={[
+          { value: 'england', label: 'England' },
+          { value: 'scotland', label: 'Scotland' },
+          { value: 'wales', label: 'Wales' },
+          { value: 'northern-ireland', label: 'Northern Ireland' }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+
+### If you’re asking more than one question on the page
+
+If you’re asking more than one question on the page, do not set the contents of
+the `<legend>` as the page heading. Read more about [asking multiple questions
+on question pages].
+
+<Canvas>
+  <Story name="No heading">
+    <FormGroup
+      id="no-heading"
+      label="Where do you live?">
+      <Radios
+        id="no-heading"
+        fieldId="where-do-you-live-no-heading"
+        options={[
+          { value: 'england', label: 'England' },
+          { value: 'scotland', label: 'Scotland' },
+          { value: 'wales', label: 'Wales' },
+          { value: 'northern-ireland', label: 'Northern Ireland' }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+### Disabled option
+
+<Canvas>
+  <Story name="Disabled option">
+    <FormGroup
+      id="disabled-option"
+      label={<h1 className="govuk-heading-l">Where do you live?</h1>}>
+      <Radios
+        id="disabled-option"
+        fieldId="where-do-you-live-disabled"
+        options={[
+          { value: 'england', label: 'England' },
+          { value: 'scotland', label: 'Scotland' },
+          { value: 'wales', label: 'Wales' },
+          { value: 'northern-ireland', label: 'Northern Ireland', disabled: true }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+### Default selected option
+
+<Canvas>
+  <Story name="Selected option">
+    {() => {
+      const OPTIONS = [
+        { value: 'england', label: 'England' },
+        { value: 'scotland', label: 'Scotland' },
+        { value: 'wales', label: 'Wales' },
+        { value: 'northern-ireland', label: 'Northern Ireland' }
+      ];
+      const value = OPTIONS[0];
+      return (
+        <FormGroup
+          id="selected"
+          label={<h1 className="govuk-heading-l">Where do you live?</h1>}>
+          <Radios
+            id="selected-option"
+            fieldId="where-do-you-live-selected"
+            options={OPTIONS}
+            value={value}
+          />
+        </FormGroup>
+      );
+    }}
+  </Story>
+</Canvas>
+
+
+### Inline radios
+
+In some cases, you can choose to display radios ‘inline’ beside one another
+(horizontally).
+
+Only use inline radios when:
+
+- the question only has two options
+- both options are short
+
+Remember that on small screens such as mobile devices, the radios will still be
+‘stacked’ on top of one another (vertically).
+
+<Canvas>
+  <Story name="Inline">
+    <FormGroup
+      id="inline"
+      hint="This includes changing your last name or spelling your name differently."
+      label={<h1 className="govuk-heading-l">Have you changed your name?</h1>}>
+      <Radios
+        classModifiers="inline"
+        id="inline"
+        fieldId="changed-name-inline"
+        options={[
+          { value: 'yes', label: 'Yes' },
+          { value: 'no', label: 'No' }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+
+### Radio items with hints
+
+You can add hints to radio items to provide additional information about the
+options.
+
+<Canvas>
+  <Story name="Hints">
+    <FormGroup
+      id="hints"
+      hint="This includes changing your last name or spelling your name differently."
+      label={<h1 className="govuk-heading-l">How do you want to sign in?</h1>}>
+      <Radios
+        id="hints"
+        fieldId="sign-in-hints"
+        options={[
+          {
+            value: 'government-gateway',
+            label: 'Sign in with Government Gateway',
+            hint: 'You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.'
+          },
+          {
+            value: 'govuk-verify',
+            label: 'Sign in with GOV.UK Verify',
+            hint: 'You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.'
+          }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+
+### Radio items with a text divider
+
+If one or more of your radio options is different from the others, it can help
+users if you separate them using a text divider. The text is usually the word
+‘or’.
+
+<Canvas>
+  <Story name="Divider">
+    <FormGroup
+      id="divider"
+      label={<h1 className="govuk-heading-l">Where do you live?</h1>}>
+      <Radios
+        id="divider"
+        fieldId="where-do-you-live-divider"
+        options={[
+          { value: 'england', label: 'England' },
+          { value: 'scotland', label: 'Scotland' },
+          { value: 'wales', label: 'Wales' },
+          { value: 'northern-ireland', label: 'Northern Ireland' },
+          'or',
+          { value: 'abroad', label: 'I am a British citizen living abroad' }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+
+Keep it simple. If the related question is complicated or has more than one
+part, show it on the next page in the process instead.
+
+Do not conditionally reveal questions to inline radios, such as ‘yes’ and ‘no’
+options placed next to each other.
+
+Conditionally reveal questions only - do not show or hide anything that is not a
+question.
+
+
+#### Known issues
+
+Users are not always notified when a conditionally revealed question is shown or
+hidden. This fails [WCAG 2.1 success criterion 4.1.2 Name, Role, Value].
+
+However, we found that screen reader users did not have difficulty answering a
+conditionally revealed question - as long as it’s kept simple. It confused our
+test users when we conditionally revealed complicated questions to them.
+
+We’ll keep looking for opportunities to [learn more about how conditionally
+revealed questions should be used in services].
+
+
+### Smaller radios
+
+Use standard-sized radios in nearly all cases. However, smaller versions work
+well on pages where it’s helpful to make them less visually prominent.
+
+For example, on a page of search results, the primary user need is to see the
+results. Using smaller radios lets users see and change search filters without
+distracting them from the main content.
+
+<Canvas>
+  <Story name="Small">
+    <FormGroup
+      id="small"
+      label={<h3>Filter</h3>}>
+      <Radios
+        classModifiers="small"
+        id="small"
+        fieldId="filter-small"
+        options={[
+          { value: 'month', label: 'Monthly' },
+          { value: 'year', label: 'Yearly' }
+        ]}
+      />
+    </FormGroup>
+  </Story>
+</Canvas>
+
+
+Small radios can work well on information dense screens in services designed for
+repeat use, like caseworking systems.
+
+In services like these, the risk that they will not be noticed is lower because
+users return to the screen multiple times.
+
+
+### Error messages
+
+Display an error message if none of the radios are selected.
+
+Error messages should be styled like this:
+
+<Canvas>
+  <Story name="Errors">
+    {() => {
+      const OPTIONS = [
+        { value: 'yes', label: 'Yes' },
+        { value: 'no', label: 'No' }
+      ];
+      const ERROR = 'Select yes if you have changed your name';
+      const [value, setValue] = useState(undefined);
+      const [error, setError] = useState(ERROR);
+      const onChange = (e) => {
+        const option = OPTIONS.find(opt => opt.value === e.target.value);
+        setValue(option);
+        setError(option ? undefined : ERROR);
+      };
+      return (
+        <FormGroup
+          id="errors"
+          hint="This includes changing your last name or spelling your name differently."
+          label={<h1 className="govuk-heading-l">Have you changed your name?</h1>}
+          error={error}>
+          <Radios
+            classModifiers="inline"
+            id="errors"
+            fieldId="changed-name-errors"
+            options={OPTIONS}
+            onChange={onChange}
+            value={value}
+          />
+        </FormGroup>
+      );
+    }}
+  </Story>
+</Canvas>
+
+Make sure errors follow the guidance in error message and have specific error
+messages for specific error states.
+
+
+#### If nothing is selected and the options are ‘yes’ and ‘no’
+
+Say ‘Select yes if [whatever it is is true]’.
+For example, ‘Select yes if Sarah normally lives with you’.
+
+
+#### If nothing is selected and the question has options in it
+
+Say ‘Select if [whatever it is]’.
+For example, ‘Select if you are employed or self-employed’.
+
+
+#### If nothing is selected and the question does not have options in it
+
+Say ‘Select [whatever it is]’.
+For example, ‘Select the day of the week you pay your rent’.
+
+
+[one question per page]: https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page
+[why and how to set legends as headings]: https://design-system.service.gov.uk/get-started/labels-legends-headings
+[WCAG 2.1 success criterion 4.1.2 Name, Role, Value]: https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html
+[learn more about how conditionally revealed questions should be used in services]: https://github.com/alphagov/govuk-design-system-backlog/issues/37

--- a/packages/components/src/Radios/Radios.stories.mdx
+++ b/packages/components/src/Radios/Radios.stories.mdx
@@ -1,5 +1,8 @@
+<!-- Global imports -->
 import { useState } from 'react';
-import { Canvas, Meta, ArgsTable, Story } from '@storybook/addon-docs';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
 import Details from '../Details';
 import FormGroup from '../FormGroup';
 import Radios from './Radios';

--- a/packages/components/src/Radios/Radios.test.js
+++ b/packages/components/src/Radios/Radios.test.js
@@ -1,5 +1,8 @@
+// Global imports
 import React from 'react';
 import { fireEvent, getByTestId, render } from '@testing-library/react';
+
+// Local imports
 import Radios, { DEFAULT_CLASS } from './Radios';
 
 describe('Radios', () => {

--- a/packages/components/src/Radios/Radios.test.js
+++ b/packages/components/src/Radios/Radios.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, getByTestId, render } from '@testing-library/react';
+import Radios, { DEFAULT_CLASS } from './Radios';
+
+describe('Radios', () => {
+
+  const OPTIONS = [
+    { value: 'england', label: 'England' },
+    { value: 'scotland', label: 'Scotland' },
+    { value: 'wales', label: 'Wales' },
+    { value: 'northern-ireland', label: 'Northern Ireland' }
+  ];
+
+  const checkSetup = (container, testId) => {
+    const wrapper = getByTestId(container, testId);
+    expect(wrapper.classList).toContain(DEFAULT_CLASS);
+    return wrapper;
+  };
+
+  const checkValueChange = (id, fieldId, rerender, value, wrapper) => {
+    const checkedValue = typeof(value) === 'object' ? value?.value : value;
+    rerender(
+      <Radios data-testid={id} id={id} fieldId={fieldId} options={OPTIONS} value={value} />
+    );
+    OPTIONS.forEach((opt, index) => {
+      const input = wrapper.childNodes[index].childNodes[0];
+      expect(input.checked).toEqual(opt.value === checkedValue);
+    });
+  };
+
+  it('should appropriately set up the necessary components', async () => {
+    const ID = 'radios';
+    const FIELD_ID = 'radiosFieldId';
+    const { container } = render(
+      <Radios data-testid={ID} id={ID} fieldId={FIELD_ID} options={OPTIONS} />
+    );
+    const wrapper = checkSetup(container, ID);
+    // Options.
+    expect(wrapper.childNodes.length).toEqual(OPTIONS.length);
+    OPTIONS.forEach((opt, index) => {
+      const item = wrapper.childNodes[index];
+      expect(item.classList).toContain(`${DEFAULT_CLASS}__item`);
+      expect(item.innerHTML).toContain(opt.label);
+      const input = item.childNodes[0];
+      expect(input.id).toEqual(`${FIELD_ID}-${index}`);
+      expect(input.name).toEqual(FIELD_ID);
+      expect(input.value).toEqual(opt.value);
+      expect(input.checked).toEqual(false);
+    });
+  });
+
+  it('should handle a change to the value', async () => {
+    const ID = 'radios';
+    const FIELD_ID = 'radiosFieldId';
+    const { container, rerender } = render(
+      <Radios data-testid={ID} id={ID} fieldId={FIELD_ID} options={OPTIONS} />
+    );
+    const wrapper = checkSetup(container, ID);
+    OPTIONS.forEach((_, index) => {
+      const input = wrapper.childNodes[index].childNodes[0];
+      expect(input.checked).toEqual(false);
+    });
+    checkValueChange(ID, FIELD_ID, rerender, OPTIONS[2], wrapper);
+    checkValueChange(ID, FIELD_ID, rerender, OPTIONS[0], wrapper);
+    checkValueChange(ID, FIELD_ID, rerender, OPTIONS[1].value, wrapper);
+    checkValueChange(ID, FIELD_ID, rerender, null, wrapper);
+  });
+
+  it('should handle clicking on one of the options', async () => {
+    const ID = 'radios';
+    const FIELD_ID = 'radiosFieldId';
+    const CHANGE_EVENTS = [];
+    const ON_CHANGE = (e) => {
+      CHANGE_EVENTS.push(e.target.value);
+    };
+    const { container } = render(
+      <Radios data-testid={ID} id={ID} fieldId={FIELD_ID} options={OPTIONS} onChange={ON_CHANGE} />
+    );
+    const wrapper = checkSetup(container, ID);
+    const input = wrapper.childNodes[2].childNodes[0]; // Third option (Wales).
+    expect(CHANGE_EVENTS.length).toEqual(0);
+    fireEvent.click(input);
+    expect(CHANGE_EVENTS.length).toEqual(1);
+    expect(CHANGE_EVENTS[0]).toEqual(OPTIONS[2].value);
+  });
+
+});

--- a/packages/components/src/Radios/index.js
+++ b/packages/components/src/Radios/index.js
@@ -1,0 +1,7 @@
+import Radio from './Radio';
+import Radios from './Radios';
+
+export default Radios;
+export {
+  Radio
+};

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -10,6 +10,7 @@ import InsetText from './InsetText';
 import Label from './Label';
 import Link from './Link';
 import Panel from './Panel';
+import Radios, { Radio } from './Radios';
 import Tag from './Tag';
 import TextInput from './TextInput';
 import Utils from './utils/Utils';
@@ -28,6 +29,8 @@ export {
   Label,
   Link,
   Panel,
+  Radio,
+  Radios,
   StartButton,
   Tag,
   TextInput,


### PR DESCRIPTION
### Description
Added the `Radios` component (and accompanying `Radio` component), along with unit tests and Storybook stories.
https://support.cop.homeoffice.gov.uk/browse/COP-8968

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`