### PR TITLE
COP-8972: Add Markup component

### DIFF
--- a/packages/components/src/Markup/Markup.jsx
+++ b/packages/components/src/Markup/Markup.jsx
@@ -1,0 +1,22 @@
+// Global imports
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const DEFAULT_TAG_NAME = 'p';
+const Markup = ({ children, tagName, className, ...attrs }) => {
+  const Tag = `${tagName}`;
+  return <Tag {...attrs} className={className}>
+    {children}
+  </Tag>;
+};
+
+Markup.propTypes = {
+  tagName: PropTypes.string.isRequired,
+  className: PropTypes.string
+};
+
+Markup.defaultProps = {
+  tagName: DEFAULT_TAG_NAME
+};
+
+export default Markup;

--- a/packages/components/src/Markup/Markup.stories.mdx
+++ b/packages/components/src/Markup/Markup.stories.mdx
@@ -1,0 +1,55 @@
+<!-- Global imports -->
+
+import { useState } from 'react';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<!-- Local imports -->
+import Details from '../Details';
+import Tag from '../Tag';
+import Markup from './Markup';
+
+<Meta title="internal/Markup" id="D-FormattedText" component={ Markup } />
+
+# Markup
+
+<p><Tag text="Internal" /></p>
+
+An element for displaying formatted text - e.g., a paragraph or heading. By default, this will be a paragraph (`p`).
+
+<Canvas>
+  <Story name="Default">
+    <Markup>
+      The changes will show in your profile when they accept your request.
+    </Markup>
+  </Story>
+</Canvas>
+
+<Details summary="Properties" className="no-indent">
+  <ArgsTable of={ Markup } />
+</Details>
+
+## Stories
+### With `tagName`.
+
+The content can be additional markup, not just plain text, and the `tagName` can be appropriately specified.
+
+<Canvas>
+  <Story name="With specified tagName">
+    <Markup tagName="ol">
+      <li>Check your answers carefully</li>
+      <li>Don't make a mistake</li>
+    </Markup>
+  </Story>
+</Canvas>
+
+### With `className`.
+
+You can specify a `className` for styling purposes.
+
+<Canvas>
+  <Story name="With specified className">
+    <Markup tagName="h1" className="govuk-heading-l">
+      Large heading
+    </Markup>
+  </Story>
+</Canvas>

--- a/packages/components/src/Markup/Markup.test.js
+++ b/packages/components/src/Markup/Markup.test.js
@@ -1,0 +1,67 @@
+// Global imports
+import React from 'react';
+import { getByTestId, render } from '@testing-library/react';
+
+// Local imports
+import Markup, { DEFAULT_TAG_NAME } from './Markup';
+
+describe('Markup', () => {
+
+  it('should display the appropriate text', async () => {
+    const MARKUP_ID = 'markupId';
+    const TEXT = 'Hello World';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID}>{TEXT}</Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.innerHTML).toEqual(TEXT);
+    expect(markup.tagName).toEqual(DEFAULT_TAG_NAME.toUpperCase());
+  });
+
+  it('should use the appropriate tagName', async () => {
+    const MARKUP_ID = 'markupId';
+    const TEXT = 'Hello World';
+    const TAG_NAME = 'div';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME}>{TEXT}</Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.innerHTML).toEqual(TEXT);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+  });
+
+  it('should use the appropriate className', async () => {
+    const MARKUP_ID = 'markupId';
+    const TEXT = 'Hello World';
+    const TAG_NAME = 'h1';
+    const CLASS_NAME = 'govuk-heading-l';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME} className={CLASS_NAME}>{TEXT}</Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.innerHTML).toEqual(TEXT);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+    expect(markup.classList).toContain(CLASS_NAME);
+  });
+
+  it('should accept internal markup as well as text and render it appropriately', async () => {
+    const MARKUP_ID = 'markupId';
+    const TAG_NAME = 'h1';
+    const CLASS_NAME = 'govuk-heading-l';
+    const INNER_TEXT = 'Hello world!';
+    const INNER_TAG_NAME = 'span';
+    const { container } = render(
+      <Markup data-testid={MARKUP_ID} tagName={TAG_NAME} className={CLASS_NAME}>
+        <Markup tagName={INNER_TAG_NAME}>{INNER_TEXT}</Markup>
+      </Markup>
+    );
+    const markup = getByTestId(container, MARKUP_ID);
+    expect(markup.tagName).toEqual(TAG_NAME.toUpperCase());
+    expect(markup.classList).toContain(CLASS_NAME);
+    expect(markup.childNodes.length).toEqual(1);
+    const innerSpan = markup.childNodes[0];
+    expect(innerSpan.innerHTML).toEqual(INNER_TEXT);
+    expect(innerSpan.tagName).toEqual(INNER_TAG_NAME.toUpperCase());
+  });
+
+});

--- a/packages/components/src/Markup/index.js
+++ b/packages/components/src/Markup/index.js
@@ -1,0 +1,6 @@
+import Markup, { DEFAULT_TAG_NAME } from './Markup';
+
+export default Markup;
+export {
+  DEFAULT_TAG_NAME
+};

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -9,6 +9,7 @@ import Hint from './Hint';
 import InsetText from './InsetText';
 import Label from './Label';
 import Link from './Link';
+import Markup from './Markup';
 import Panel from './Panel';
 import Radios, { Radio } from './Radios';
 import Tag from './Tag';
@@ -28,6 +29,7 @@ export {
   InsetText,
   Label,
   Link,
+  Markup,
   Panel,
   Radio,
   Radios,


### PR DESCRIPTION
### Description
Added the `Markup` component, along with unit tests and Storybook stories.
https://support.cop.homeoffice.gov.uk/browse/COP-8972

### To test
The component library itself offers Storybook for the purposes of evaluating the rendering of the components and their variations. Proper testing will likely be best achieved when the components are used in COP-8193, COP-8376, and COP-8386, which will be within https://github.com/UKHomeOffice/cop-ui.

Instructions to see the components within Storybook are in the `README.md` files, but the TLDR version is to run the following in the project root (or in `packages/components`):
* `> yarn install`
* `> yarn storybook`